### PR TITLE
v0.7.0: adaptive context sizing & KV-aware auto-configuration

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@
 ## Current Build Status
 
 - **Build:** ✅ 0 TypeScript errors
-- **Tests:** ✅ 488/488 passing (20 suites)
+- **Tests:** ✅ 506/506 passing (21 suites)
 - **Branch:** `feat/v0.6.0-local-server`
 - **Last Updated:** 2026-07-03 (v0.6.1: security patch — npm audit clean, tar minimum ^7.5.19)
 
@@ -495,3 +495,20 @@ For detailed historical information:
 - **Example-app toolchain chore** — Electron Forge devDependency chain carries npm-audit highs fixable only via major bumps (electron 35→43 + Forge majors). Dev-only, outside the published package and CI's root-only audit gate.
 - **ROCm/HIP binary variants** — upstream now ships `win-hip-radeon` + `ubuntu-rocm` prebuilts; blocked on Windows AMD GPU detection (DESIGN Phase 4).
 - **genai-lite**: `GenaiElectronImageAdapter` should treat `'cancelled'` as terminal — filed and committed in that repo (`docs/ISSUE-cancelled-generation-status.md`).
+
+---
+
+## v0.7.0: Adaptive Context Sizing & KV-Aware Auto-Configuration (2026-07-03)
+
+**Goal/Problem:** `recommendContextSize` was a stub returning a constant 4096, so every auto-configured server ran a ≤4K context regardless of hardware — silently truncating long prompts (hit by palimpsest-engine; `docs/dev/issues/ISSUE-context-size-recommendation.md`). The flat 2 GB KV reserve in layer packing could also push almost-fitting models into partial offload.
+
+**Core Features:**
+- Real KV-cache arithmetic (`estimateKVBytesPerToken`, GQA-aware via `attention.head_count_kv`; new GGUF fields extracted, raw-metadata fallback for older downloads)
+- `getOptimalConfig(modelInfo, hints?)`: full-GPU-offload-preferring layer packing (KV reserve flexes down to the 4096-token floor), context sized from leftover VRAM/RAM with **no artificial ceiling** (capped by the model's own context_length), rounded to 1024
+- **Automatic q8_0 KV quantization by default** (+ flash attention on) unless f16 at the model's full native context fits — opt out via explicit `cacheTypeK/V: 'f16'` or `flashAttention: 'off'`; pinned hints (contextSize/gpuLayers/cache types) shape the remaining recommendations
+- KV-aware `canRunModel` and ResourceOrchestrator usage estimates; legacy behavior preserved exactly for models without GGUF metadata
+- New exports: `estimateKVBytesPerToken`, `KV_CACHE_BYTES_PER_ELEMENT`, `KV_SIZING`, `OptimalConfigHints`
+
+**Files Modified:** `src/utils/kv-cache-math.ts` (new), `src/utils/model-metadata-helpers.ts`, `src/system/SystemInfo.ts`, `src/managers/{LlamaServerManager,ModelManager,ResourceOrchestrator}.ts`, `src/config/defaults.ts`, `src/types/{models,servers,index}.ts`, `src/index.ts`, docs (`system-detection`, `llm-server`, `typescript-reference`, `image-generation`, `migration-0-6-to-0-7.md`)
+
+**Build Status:** ✅ 0 TypeScript errors / 506/506 tests passing (21 suites); live GPU smoke: pure auto-config on Qwen3.5-4B → full offload, auto q8_0 KV + FA, context ≫ 4096, >4K-token prompt round-trips without truncation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai-electron
 
-> **Version**: 0.6.1 | **Status**: Production Ready - LLM & Image Generation, hardened server lifecycle
+> **Version**: 0.7.0 | **Status**: Production Ready - LLM & Image Generation, hardened server lifecycle
 
 Electron-specific library for managing local AI model servers (llama.cpp, stable-diffusion.cpp). Handles platform-specific operations to run AI models locally. Complements [genai-lite](https://github.com/lacerbi/genai-lite) for API abstraction.
 

--- a/docs/dev/issues/ISSUE-context-size-recommendation.md
+++ b/docs/dev/issues/ISSUE-context-size-recommendation.md
@@ -1,0 +1,59 @@
+# ISSUE: getOptimalConfig() pins contextSize at 4096 — recommendContextSize is a stub
+
+Created: 2026-07-03
+Status: RESOLVED (2026-07-03, v0.7.0) — full adaptive-sizing fix implemented:
+GQA-aware KV math from GGUF metadata, full-offload-preferring layer packing,
+automatic q8_0 KV selection, and KV-aware canRunModel/orchestrator estimates.
+See genai-electron-docs/migration-0-6-to-0-7.md and
+docs/dev/plans/PLAN-adaptive-context-sizing.md.
+Package: genai-electron (filed from palimpsest-engine 0.6.1 integration work)
+
+## Problem
+
+`SystemInfo.recommendContextSize(_availableRAM, _modelSize)`
+(src/system/SystemInfo.ts:331-335) ignores both parameters and returns a
+constant 4096 (llama.cpp's default). `getOptimalConfig()` (:240-269) computes
+`contextSize = min(modelContextLength, recommendContextSize(...))`, so the
+returned context is **always ≤ 4096 regardless of hardware** — on a 24 GB GPU
+with a 256K-context model, same as on an 8 GB laptop. The fresh memory info
+fetched at :243-244 feeds only this dead parameter.
+
+The API surface implies otherwise: the method is documented as "optimal
+server config for a model based on system capabilities", takes RAM/model-size
+parameters, and sits next to genuinely adaptive logic (`calculateGPULayers`).
+Consumers that trust it (the natural integration path shown in the docs) run
+4K-context servers everywhere; LLM apps with long prompts (chat history,
+context injection) silently truncate at llama-server with no error.
+
+palimpsest-engine hit exactly this: its GM prompt's history budget alone is
+~4000 tokens, so real prompts overflowed the 4096 window. It now bypasses the
+recommendation and sets `contextSize` itself (VRAM-tiered 8192/32768, bounded
+by `ggufMetadata.context_length`).
+
+## Fix
+
+Implement real sizing, using data the library already has:
+
+1. Estimate KV bytes/token from parsed GGUF metadata (`block_count`,
+   `attention_head_count` / KV heads, `embedding_length`; gguf-parser's
+   arch-field access already resolves these), honoring `cacheTypeK/V`
+   quantization when set.
+2. Budget = (VRAM when offloading, else RAM) minus weights and a compute
+   buffer margin; contextSize = clamp(budget / bytesPerToken, floor 4096,
+   cap `ggufMetadata.context_length`).
+3. Round down to a sane granularity (e.g. multiples of 1024).
+
+Minimal alternative if adaptive sizing is out of scope: keep the constant but
+document it explicitly in `getOptimalConfig()`'s JSDoc ("contextSize is a
+fixed 4096 default — override for long-context workloads"), and drop the
+misleading unused parameters.
+
+## Notes
+
+- Severity: medium — silent quality degradation (truncation), not a crash.
+- Sliding-window models (Gemma family) have much cheaper effective KV than
+  full-attention models; a first pass can ignore this (conservative) and
+  refine later.
+- Related: `recommendParallelRequests` (:350-355) already went through the
+  same "constant is better than wrong heuristic" reasoning — if the same
+  conclusion is reached here, the fix is the documentation variant.

--- a/docs/dev/plans/PLAN-adaptive-context-sizing.md
+++ b/docs/dev/plans/PLAN-adaptive-context-sizing.md
@@ -1,0 +1,77 @@
+# Plan: Adaptive Context Sizing & KV-Aware Auto-Configuration (v0.7.0)
+
+Created: 2026-07-03
+Status: COMPLETE (2026-07-03) — implemented, tested (506/506), live-verified on GPU
+Resolves: ISSUE-context-size-recommendation.md (filed from palimpsest-engine integration)
+
+## Summary
+
+Replace the `recommendContextSize` stub (constant 4096) with real KV-cache math from GGUF
+metadata, restructure `calculateGPULayers` policy to prefer **full GPU offload** (flexible
+KV reserve instead of the flat 2 GB), auto-select **q8_0 KV quantization by default**
+(f16 only when headroom is abundant), and make `canRunModel` / ResourceOrchestrator
+estimates KV-aware. Ships as v0.7.0 (behavior change: auto-configured servers offload
+more aggressively and allocate larger KV caches).
+
+## User-approved design decisions
+
+1. **No ceiling** on auto-recommended context beyond the model's own `context_length`.
+2. **KV quant auto-selection is ON by default**, leaning q8_0 (small quality loss):
+   f16 only when f16 KV at the model's FULL native context fits alongside fully-offloaded
+   weights ("abundant headroom"). Explicit user `cacheTypeK/V` (incl. `'f16'`) always wins;
+   explicit `flashAttention: 'off'`/`false` suppresses auto-quantization (quantized V needs FA).
+3. **Full-offload preference**: if shrinking the KV reserve down to the floor-context
+   (4096 × bytes/token) fits ALL layers in VRAM, do full offload; context then gets all
+   leftover VRAM. Partial offload only when full genuinely doesn't fit.
+4. `canRunModel` and orchestrator `estimateLLMUsage` updated to include real KV cost.
+
+## Algorithm (getOptimalConfig)
+
+- `bytesPerToken = layers × kvHeads × headDim × (bytes(K) + bytes(V))`
+  - kvHeads: `attention.head_count_kv` (GQA-correct!) → fallback `head_count`
+  - headDim: `attention.key_length` → fallback `embedding_length / head_count`
+  - per-element bytes from llama.cpp block layouts (f16 2, q8_0 1.0625, q4_0 0.5625, ...)
+- Budget: `(vramAvailable ?? vram) − computeBuffer(1 GiB)`; weights at 1.1× on GPU, 1.2× on CPU.
+- **Full offload** if `weights×1.1 + 4096×bpt ≤ budget` → `gpuLayers = totalLayers`,
+  `ctx = clamp(⌊(budget − weights×1.1)/bpt⌋, 4096, modelCtx)` rounded down to 1024.
+- **Partial** otherwise: reserve `max(4096×bpt, 1.5 GiB)` (or `userCtx×bpt` when contextSize
+  is user-pinned), pack layers; ctx bounded by BOTH the GPU reserve share and RAM share.
+- **CPU-only**: ctx from `available RAM − weights×1.2 − 2 GiB` ; keep f16 KV (no FA-on-CPU
+  questions).
+- **No GGUF metadata** → exact legacy behavior (4096 + old layer packing, no quant rec).
+- User-pinned `gpuLayers`/`contextSize` hints inform the other dimension's math.
+
+## Work
+
+1. [x] `src/utils/kv-cache-math.ts` (new): `KV_CACHE_BYTES_PER_ELEMENT` map,
+   `estimateKVBytesPerToken(modelInfo, cacheTypeK?, cacheTypeV?)`; export from index.
+2. [x] GGUF metadata: add `attention_head_count_kv` + `attention_key_length` to
+   `GGUFMetadata` type and `createGGUFMetadataFromParsed` (via `getArchField`); new
+   fallback helpers `getKVHeadCountWithFallback` / `getHeadDimWithFallback` in
+   model-metadata-helpers (raw-metadata lookup for already-downloaded models).
+3. [x] `SystemInfo.getOptimalConfig(modelInfo, hints?)` rewrite per algorithm; return type
+   widens to `Partial<LlamaServerConfig>` (adds cacheTypeK/V, flashAttention when
+   auto-quant chosen); `recommendContextSize` stub deleted; sizing constants in defaults.ts.
+4. [x] `LlamaServerManager.autoConfigureIfNeeded`: pass user hints; merge cacheTypeK/V +
+   flashAttention with `??` (user wins); `fit: 'on'` skips ALL auto-sizing incl. quant.
+5. [x] `canRunModel`: include floor-context KV in the RAM requirement when metadata present.
+6. [x] `ResourceOrchestrator.estimateLLMUsage`: weights + real KV (configured ctx × bpt with
+   configured cache types), split by GPU ratio; zero-KV fallback without metadata.
+7. [x] Tests: kv-cache-math unit suite (GQA vs MHA vs quantized); getOptimalConfig scenario
+   matrix (abundant→f16, long-ctx→q8_0+fa, partial, CPU-only, no-metadata legacy, hint
+   precedence, fa-off suppression); autoconfig merge + flag emission; canRunModel/orchestrator
+   updates.
+8. [x] Docs: system-detection.md (getOptimalConfig section rewrite), llm-server.md
+   auto-config notes, typescript-reference.md signature, `migration-0-6-to-0-7.md`
+   (behavior changes + how to opt out: `cacheTypeK/V: 'f16'`, explicit contextSize),
+   index/README versions, PROGRESS entry.
+9. [x] ISSUE resolved & archived (docs/dev/issues/, Status: RESOLVED); version 0.7.0; PR + tag done.
+
+## Verification
+
+- [x] 0 TS errors, lint clean, 506/506 tests (21 suites).
+- [x] Live GPU smoke PASSED (2026-07-03): pure auto-config on Qwen3.5-4B (real GGUF
+  metadata: 32 layers, 4 KV heads, key_length 256 — validating the GQA + key_length
+  extraction paths) → `-ngl 32` full offload, auto `--cache-type-k/v q8_0` + `-fa on`,
+  **context 58368** (vs the old constant 4096), confirmed via /props; an 8130-token
+  prompt round-tripped with the secret from the prompt start retrieved (no truncation).

--- a/genai-electron-docs/image-generation.md
+++ b/genai-electron-docs/image-generation.md
@@ -154,7 +154,7 @@ Returns the registry ID of the async generation currently being processed, or `u
 getActiveGenerationId(): string | undefined
 ```
 
-> **genai-lite polling caveat:** genai-lite clients at or below v0.9.0 only treat `complete` and `error` as terminal statuses. If a generation is cancelled out-of-band (via `cancelImageGeneration()` or the DELETE endpoint from a different code path), those clients keep polling until their own client-side timeout (~120 s) rather than stopping immediately. A follow-up is filed in genai-lite.
+> **genai-lite polling caveat:** genai-lite clients **below v0.9.2** only treat `complete` and `error` as terminal statuses — if a generation is cancelled out-of-band, they keep polling until their own client-side timeout (~120 s). genai-lite ≥ 0.9.2 recognizes `'cancelled'` as terminal and stops immediately (surfacing an abort error).
 
 ---
 

--- a/genai-electron-docs/index.md
+++ b/genai-electron-docs/index.md
@@ -1,6 +1,6 @@
 # genai-electron Documentation
 
-> **Version**: 0.6.1 (Local-Server Launch Contract, Multi-Shard Models & Reliability)
+> **Version**: 0.7.0 (Adaptive Context Sizing & KV-Aware Auto-Configuration)
 > **Status**: Production Ready - LLM & Image Generation
 
 Complete documentation for genai-electron - An Electron-specific library for managing local AI model servers and resources.
@@ -26,6 +26,7 @@ Complete documentation for genai-electron - An Electron-specific library for man
 - **[Troubleshooting](troubleshooting.md)** - Common issues, error codes, FAQ
 
 ### Migration
+- **[Migrating from v0.6.x to v0.7.0](migration-0-6-to-0-7.md)** - Adaptive context sizing, automatic q8_0 KV quantization, full-offload preference
 - **[Migrating from v0.5.x to v0.6.0](migration-0-5-to-0-6.md)** - Optional/`'auto'` ports, always-on `--jinja`, multi-shard models, generation cancellation
 - **[Migrating from v0.4.x to v0.5.0](migration-0-4-to-0-5.md)** - Multi-component models, presets, Flux 2 Klein
 

--- a/genai-electron-docs/llm-server.md
+++ b/genai-electron-docs/llm-server.md
@@ -193,7 +193,7 @@ interface LlamaServerConfig extends ServerConfig {
 
 `KVCacheType` is `'f16' | 'bf16' | 'q8_0' | 'q4_0' | 'q4_1' | 'q5_0' | 'q5_1' | 'iq4_nl'`, and `FlashAttentionSetting` is `boolean | 'on' | 'off' | 'auto'`. See [TypeScript Reference](typescript-reference.md) for the full definitions.
 
-When `threads` and `gpuLayers` are not specified, the library auto-configures based on system capabilities and model metadata.
+When `threads`, `gpuLayers`, `contextSize`, or the KV-cache fields are not specified, the library auto-configures based on system capabilities and GGUF metadata (v0.7.0 adaptive sizing): full GPU offload is preferred, the context recommendation comes from real KV-cache arithmetic (no artificial ceiling — capped only by the model's own context length), and **q8_0 KV quantization + flash attention are auto-selected by default** unless f16 KV at the model's full native context comfortably fits. Opt out of auto-quantization with `cacheTypeK/V: 'f16'` or `flashAttention: 'off'`; an explicit `contextSize` is always respected verbatim. Models without GGUF metadata keep the legacy behavior (fixed 4096 context). See [System Detection](system-detection.md) for the full algorithm.
 
 **About `port` and `'auto'`:**
 `port` is optional and defaults to 8080. Pass `'auto'` to have the OS assign a free port — useful when 8080 may already be taken. The resolved numeric port is reported on `ServerInfo.port` (from `getInfo()`) and on `getPort()`. Reliability features such as auto-restart reuse the resolved port rather than re-running `'auto'`.

--- a/genai-electron-docs/migration-0-6-to-0-7.md
+++ b/genai-electron-docs/migration-0-6-to-0-7.md
@@ -1,0 +1,74 @@
+# Migrating from v0.6.x to v0.7.0
+
+v0.7.0 replaces the fixed 4096-token context recommendation with **adaptive, KV-cache-aware auto-configuration**. Auto-configured servers now prefer full GPU offload, size their context window from real KV arithmetic, and select q8_0 KV quantization by default. Explicit configuration is always respected — the changes below apply only to fields you leave unset.
+
+## Compatibility
+
+All API changes are additive and source-compatible. The behavioral changes affect **auto-configured** servers (models with GGUF metadata; models without metadata keep the exact v0.6 behavior):
+
+- **Context size is no longer pinned at 4096.** The recommendation comes from `layers × kvHeads × headDim × bytes-per-element` arithmetic against available VRAM/RAM, clamped only by the model's own `context_length` (no artificial ceiling) and rounded down to 1024. A small model on a large GPU can now get a very large context — with a correspondingly large KV allocation at server startup.
+- **q8_0 KV quantization is auto-selected by default** (together with `flashAttention: 'on'`), unless f16 KV at the model's *full native context* fits alongside fully-offloaded weights. The quality impact of q8_0 KV is typically negligible; it roughly doubles the affordable context. **Opt out** with `cacheTypeK: 'f16', cacheTypeV: 'f16'` or `flashAttention: 'off'`.
+- **Full GPU offload is preferred.** The old flat 2 GB KV reserve could push a model that *almost* fit into partial offload; the reserve now flexes down to the floor-context (4096-token) cost to win full offload, since partial offload is a large performance cliff.
+- **VRAM/RAM usage estimates are KV-aware.** `canRunModel()` includes the floor-context KV cost, and the ResourceOrchestrator's offload decisions account for the configured context's KV — expect slightly more conservative co-running decisions with large contexts.
+- `getOptimalConfig()` now returns `Partial<LlamaServerConfig>` (was `Partial<ServerConfig>`) and may include `cacheTypeK`, `cacheTypeV`, and `flashAttention`.
+
+**If you relied on the old defaults**: pass `contextSize: 4096` (and `cacheTypeK/V: 'f16'`) explicitly to reproduce v0.6 behavior exactly.
+
+## What's New
+
+| Feature | Summary |
+| --- | --- |
+| Adaptive context sizing | Context recommendation from real KV-cache math (GQA-aware via `attention.head_count_kv`) |
+| Full-offload preference | KV reserve flexes (floor: 4096 tokens' worth) so full GPU offload wins whenever possible |
+| Automatic KV quantization | q8_0 K/V + flash attention chosen by default when it buys context; f16 kept when headroom is abundant |
+| Sizing hints | `getOptimalConfig(modelInfo, hints)` — pinned fields shape the recommendations for the rest |
+| KV arithmetic export | `estimateKVBytesPerToken(modelInfo, cacheTypeK?, cacheTypeV?)` + `KV_CACHE_BYTES_PER_ELEMENT` |
+| KV-aware estimates | `canRunModel()` and ResourceOrchestrator estimates include real KV cost |
+
+## New Types
+
+### OptimalConfigHints
+
+```typescript
+type OptimalConfigHints = Partial<
+  Pick<
+    LlamaServerConfig,
+    'contextSize' | 'gpuLayers' | 'parallelRequests' | 'flashAttention' | 'cacheTypeK' | 'cacheTypeV'
+  >
+>;
+```
+
+## Extended Interfaces
+
+### GGUFMetadata
+
+```typescript
+interface GGUFMetadata {
+  // ... existing fields ...
+  attention_head_count_kv?: number; // KV heads (GQA)
+  attention_key_length?: number; // per-head key dimension
+}
+```
+
+Both fields are extracted for newly downloaded models; models downloaded earlier are read from the stored `raw` metadata automatically.
+
+## New Exports
+
+- `estimateKVBytesPerToken(modelInfo, cacheTypeK?, cacheTypeV?)` — per-token KV cost in bytes
+- `KV_CACHE_BYTES_PER_ELEMENT` — bytes-per-element map matching llama.cpp's block layouts
+- `KV_SIZING` — the sizing constants (floor context, compute buffer, margins)
+- `OptimalConfigHints` (type)
+
+## How the sizing works
+
+1. **Cache types**: q8_0 K/V unless f16 KV at the model's full native context fits alongside fully-offloaded weights; explicit user cache types or `flashAttention: 'off'` win; CPU-only stays f16.
+2. **Full offload** if `weights × 1.1 + 4096-token KV ≤ (available VRAM − 1 GB compute buffer)` → all layers on GPU, and all leftover VRAM becomes context budget.
+3. **Partial offload** otherwise: reserve `max(floor KV, 1.5 GB)`, pack layers, bound context by both the GPU reserve share and available RAM.
+4. **CPU-only**: context from `available RAM − weights × 1.2 − 2 GB`.
+5. Clamp to `[4096, model context_length]`, round down to 1024.
+
+## See Also
+
+- [System Detection](system-detection.md) — `getOptimalConfig()` reference
+- [LLM Server](llm-server.md) — configuration options
+- [Migrating 0.5 → 0.6](migration-0-5-to-0-6.md)

--- a/genai-electron-docs/system-detection.md
+++ b/genai-electron-docs/system-detection.md
@@ -224,13 +224,18 @@ Generates optimal server configuration for a specific model based on system capa
 
 **Signature**:
 ```typescript
-getOptimalConfig(modelInfo: ModelInfo): Promise<Partial<ServerConfig>>
+getOptimalConfig(
+  modelInfo: ModelInfo,
+  hints?: OptimalConfigHints  // fields you've already pinned (contextSize, gpuLayers,
+                              // cacheTypeK/V, flashAttention, parallelRequests)
+): Promise<Partial<LlamaServerConfig>>
 ```
 
 **Parameters**:
-- `modelInfo: ModelInfo` - Model to generate config for
+- `modelInfo: ModelInfo` - Model to generate config for (GGUF metadata enables the adaptive sizing below)
+- `hints?: OptimalConfigHints` - Fields the caller has already decided; they are respected verbatim and inform the sizing of the remaining ones (e.g. a pinned `contextSize` shapes the KV reserve used for GPU-layer packing; explicit cache types or `flashAttention: 'off'` suppress automatic KV quantization)
 
-**Returns**: `Promise<Partial<ServerConfig>>` - Partial server configuration (threads, gpuLayers, contextSize, etc.) meant to be spread into full `start()` call. Does not include `modelId` or `port`.
+**Returns**: `Promise<Partial<LlamaServerConfig>>` - Partial server configuration (threads, gpuLayers, contextSize, and — when auto-selected — cacheTypeK/V + flashAttention) meant to be spread into a full `start()` call. Does not include `modelId` or `port`.
 
 **Example**:
 ```typescript
@@ -251,11 +256,14 @@ await llamaServer.start({
 });
 ```
 
-**What it determines**:
+**What it determines** (v0.7.0 adaptive sizing — requires GGUF metadata; models without it get the legacy behavior: fixed 4096 context, flat 2 GB KV reserve):
 - **threads**: Based on CPU core count: 1-2 cores → all cores, 3-8 → cores - 1, 9-16 → cores - 2, 17+ → floor(cores × 0.85)
-- **gpuLayers**: Maximum layers that fit in VRAM (if GPU available), or 0 for CPU-only. Reserves 2GB of VRAM as buffer for OS/runtime overhead before calculating layer capacity.
-- **contextSize**: Currently defaults to 4096 (llama.cpp default), capped to the model's native context length from GGUF metadata. VRAM-aware dynamic context calculation is planned but not yet implemented.
+- **gpuLayers**: **Full GPU offload is preferred** — if all weights fit in VRAM alongside at least a 4096-token KV cache (plus a ~1 GB compute buffer), every layer is offloaded. Only when that's impossible are layers packed around a KV reserve (min 1.5 GB).
+- **contextSize**: Computed from real KV-cache arithmetic (`layers × kvHeads × headDim × bytes-per-element`, GQA-aware via `attention.head_count_kv`): all VRAM left after weights becomes context budget, clamped to `[4096, model's context_length]` and rounded down to 1024. **There is no artificial ceiling** — a small model on a large GPU can get a very large context (and a correspondingly large KV allocation at server startup).
+- **cacheTypeK / cacheTypeV / flashAttention**: **q8_0 KV quantization is auto-selected by default** (~2× cheaper KV, small quality loss) together with `flashAttention: 'on'`, *unless* f16 KV at the model's full native context fits alongside fully-offloaded weights (abundant headroom → stays f16, no fields emitted). Opt out by setting `cacheTypeK/V: 'f16'` explicitly or `flashAttention: 'off'`.
 - **parallelRequests**: Always 1 (single-user Electron apps)
+
+Use `estimateKVBytesPerToken(modelInfo, cacheTypeK?, cacheTypeV?)` (exported) to run the same KV arithmetic yourself.
 
 ---
 

--- a/genai-electron-docs/typescript-reference.md
+++ b/genai-electron-docs/typescript-reference.md
@@ -151,6 +151,8 @@ interface GGUFMetadata {
   block_count?: number;
   context_length?: number;
   attention_head_count?: number;
+  attention_head_count_kv?: number; // KV heads (GQA); fewer than head_count on modern models
+  attention_key_length?: number; // per-head key dim, when != embedding_length / head_count
   embedding_length?: number;
   feed_forward_length?: number;
   vocab_size?: number;
@@ -611,6 +613,22 @@ interface LogRotationOptions {
 ---
 
 ## Resource Types
+
+### OptimalConfigHints
+
+Fields the caller has already pinned when asking `systemInfo.getOptimalConfig(modelInfo, hints?)` for recommendations. Pinned values are respected verbatim and inform the sizing of the remaining dimensions; explicit cache types or `flashAttention: 'off'` suppress automatic KV quantization.
+
+```typescript
+type OptimalConfigHints = Partial<
+  Pick<
+    LlamaServerConfig,
+    'contextSize' | 'gpuLayers' | 'parallelRequests' | 'flashAttention' | 'cacheTypeK' | 'cacheTypeV'
+  >
+>;
+```
+
+`getOptimalConfig` returns `Promise<Partial<LlamaServerConfig>>` (may include auto-selected `cacheTypeK`/`cacheTypeV`/`flashAttention`). The KV arithmetic is exported as `estimateKVBytesPerToken(modelInfo, cacheTypeK?, cacheTypeV?)`.
+
 
 ### SavedLLMState
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-electron",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-electron",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/gguf": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-electron",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Electron-specific library for managing local AI model servers and resources",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -40,6 +40,26 @@ export const DEFAULT_LOG_ROTATION = {
 } as const;
 
 /**
+ * Constants for KV-cache-aware context/offload sizing (SystemInfo.getOptimalConfig)
+ */
+export const KV_SIZING = {
+  /** Minimum recommended context (llama.cpp's historical default) */
+  floorContextTokens: 4096,
+  /** VRAM held back for llama.cpp compute/graph buffers and allocator slack */
+  computeBufferBytes: 1 * 1024 ** 3,
+  /** Weight-size multiplier for GPU-resident weights */
+  gpuWeightsOverhead: 1.1,
+  /** Weight-size multiplier for RAM-resident weights */
+  cpuWeightsOverhead: 1.2,
+  /** RAM held back for the OS and other processes in CPU sizing paths */
+  osRamMarginBytes: 2 * 1024 ** 3,
+  /** Minimum VRAM reserved for KV when partially offloading */
+  minPartialReserveBytes: 1.5 * 1024 ** 3,
+  /** Context recommendations are rounded down to this granularity */
+  contextGranularityTokens: 1024,
+} as const;
+
+/**
  * Binary variant type
  */
 export type BinaryVariant = 'cuda' | 'vulkan' | 'metal' | 'cpu';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * to run AI models locally on desktop systems.
  *
  * @module genai-electron
- * @version 0.6.1
+ * @version 0.7.0
  * @license MIT
  *
  * @example
@@ -204,6 +204,7 @@ export {
   normalizeHealthHost,
 } from './process/health-check.js';
 export { findFreePort, isPortBindable } from './process/port-utils.js';
+export { estimateKVBytesPerToken, KV_CACHE_BYTES_PER_ELEMENT } from './utils/kv-cache-math.js';
 export { getCPUInfo, getRecommendedThreads } from './system/cpu-detect.js';
 export { getMemoryInfo, estimateVRAM } from './system/memory-detect.js';
 export { detectGPU } from './system/gpu-detect.js';
@@ -285,6 +286,7 @@ export type {
   ServerEvent,
   ServerEventData,
   BinaryLogEvent,
+  OptimalConfigHints,
   // Image generation types (Phase 2)
   ImageSampler,
   ImageGenerationStage,

--- a/src/managers/LlamaServerManager.ts
+++ b/src/managers/LlamaServerManager.ts
@@ -461,12 +461,21 @@ export class LlamaServerManager extends ServerManager {
   ): Promise<ResolvedLlamaServerConfig> {
     debugLog('[LlamaServer] autoConfigureIfNeeded input:', JSON.stringify(config));
 
-    const optimalConfig = await this.systemInfo.getOptimalConfig(modelInfo);
+    const llamaConfig = config as LlamaServerConfig & { port: number };
+    const optimalConfig = await this.systemInfo.getOptimalConfig(modelInfo, {
+      contextSize: llamaConfig.contextSize,
+      gpuLayers: llamaConfig.gpuLayers,
+      parallelRequests: llamaConfig.parallelRequests,
+      flashAttention: llamaConfig.flashAttention,
+      cacheTypeK: llamaConfig.cacheTypeK,
+      cacheTypeV: llamaConfig.cacheTypeV,
+    });
     debugLog('[LlamaServer] Optimal config:', JSON.stringify(optimalConfig));
 
     // With fit: 'on', llama-server's own auto-fit sizes unset memory-related
-    // fields — leave gpuLayers/contextSize unset instead of filling them here.
-    const delegateToFit = (config as LlamaServerConfig).fit === 'on';
+    // fields — leave gpuLayers/contextSize/cache recommendations unset instead
+    // of filling them here.
+    const delegateToFit = llamaConfig.fit === 'on';
 
     const finalConfig = {
       ...config,
@@ -474,7 +483,10 @@ export class LlamaServerManager extends ServerManager {
       contextSize: config.contextSize ?? (delegateToFit ? undefined : optimalConfig.contextSize),
       gpuLayers: config.gpuLayers ?? (delegateToFit ? undefined : optimalConfig.gpuLayers),
       parallelRequests: config.parallelRequests ?? optimalConfig.parallelRequests,
-      flashAttention: config.flashAttention ?? optimalConfig.flashAttention,
+      flashAttention:
+        config.flashAttention ?? (delegateToFit ? undefined : optimalConfig.flashAttention),
+      cacheTypeK: llamaConfig.cacheTypeK ?? (delegateToFit ? undefined : optimalConfig.cacheTypeK),
+      cacheTypeV: llamaConfig.cacheTypeV ?? (delegateToFit ? undefined : optimalConfig.cacheTypeV),
     } as ResolvedLlamaServerConfig;
 
     debugLog('[LlamaServer] Final config:', JSON.stringify(finalConfig));

--- a/src/managers/ModelManager.ts
+++ b/src/managers/ModelManager.ts
@@ -1051,6 +1051,12 @@ export class ModelManager {
       attention_head_count: getArchField(parsedGGUF.metadata, 'attention.head_count') as
         | number
         | undefined,
+      attention_head_count_kv: getArchField(parsedGGUF.metadata, 'attention.head_count_kv') as
+        | number
+        | undefined,
+      attention_key_length: getArchField(parsedGGUF.metadata, 'attention.key_length') as
+        | number
+        | undefined,
       embedding_length: getArchField(parsedGGUF.metadata, 'embedding_length') as number | undefined,
       feed_forward_length: getArchField(parsedGGUF.metadata, 'feed_forward_length') as
         | number

--- a/src/managers/ResourceOrchestrator.ts
+++ b/src/managers/ResourceOrchestrator.ts
@@ -12,7 +12,13 @@ import { SystemInfo } from '../system/SystemInfo.js';
 import type { LlamaServerManager } from './LlamaServerManager.js';
 import type { DiffusionServerManager } from './DiffusionServerManager.js';
 import { ModelManager } from './ModelManager.js';
-import type { ServerConfig, ImageGenerationConfig, ImageGenerationResult } from '../types/index.js';
+import type {
+  ServerConfig,
+  LlamaServerConfig,
+  ImageGenerationConfig,
+  ImageGenerationResult,
+} from '../types/index.js';
+import { estimateKVBytesPerToken } from '../utils/kv-cache-math.js';
 import { ServerError } from '../errors/index.js';
 import { debugLog } from '../utils/debug-log.js';
 
@@ -256,16 +262,25 @@ export class ResourceOrchestrator {
       // Get actual layer count from GGUF metadata (or fallback to estimation)
       const totalLayers = await this.modelManager.getModelLayerCount(config.modelId);
 
+      // Real KV-cache cost for the configured context (0 without metadata,
+      // matching the legacy weights-only estimate)
+      const llamaConfig = config as LlamaServerConfig;
+      const kvBytes = modelInfo.ggufMetadata?.block_count
+        ? (llamaConfig.contextSize ?? 4096) *
+          estimateKVBytesPerToken(modelInfo, llamaConfig.cacheTypeK, llamaConfig.cacheTypeV)
+        : 0;
+
       debugLog('[Orchestrator] LLM model:', config.modelId);
       debugLog('[Orchestrator] LLM model size:', modelInfo.size / 1024 ** 3, 'GB');
       debugLog('[Orchestrator] LLM GPU layers:', gpuLayers, '/', totalLayers);
+      debugLog('[Orchestrator] LLM KV cache:', kvBytes / 1024 ** 3, 'GB');
 
       if (gpuLayers > 0) {
-        // Mixed GPU/CPU
+        // Mixed GPU/CPU: KV follows the layer split
         const gpuRatio = Math.min(gpuLayers / totalLayers, 1.0);
         const result = {
-          ram: modelInfo.size * (1 - gpuRatio) * 1.2,
-          vram: modelInfo.size * gpuRatio * 1.2,
+          ram: (modelInfo.size * 1.2 + kvBytes) * (1 - gpuRatio),
+          vram: (modelInfo.size * 1.2 + kvBytes) * gpuRatio,
         };
         debugLog('[Orchestrator] LLM usage (mixed):', {
           ram: `${result.ram / 1024 ** 3} GB`,
@@ -275,7 +290,7 @@ export class ResourceOrchestrator {
       } else {
         // CPU only
         const result = {
-          ram: modelInfo.size * 1.2,
+          ram: modelInfo.size * 1.2 + kvBytes,
           vram: 0,
         };
         debugLog('[Orchestrator] LLM usage (CPU-only):', {

--- a/src/system/SystemInfo.ts
+++ b/src/system/SystemInfo.ts
@@ -7,17 +7,21 @@ import type {
   SystemCapabilities,
   SystemRecommendations,
   ModelInfo,
-  ServerConfig,
+  LlamaServerConfig,
+  KVCacheType,
+  OptimalConfigHints,
 } from '../types/index.js';
 import { getCPUInfo, getRecommendedThreads } from './cpu-detect.js';
 import { getMemoryInfo, estimateVRAM } from './memory-detect.js';
 import { detectGPU, calculateGPULayers } from './gpu-detect.js';
 import { getPlatform } from '../utils/platform-utils.js';
-import { RECOMMENDED_QUANTIZATIONS } from '../config/defaults.js';
+import { RECOMMENDED_QUANTIZATIONS, KV_SIZING } from '../config/defaults.js';
 import {
   getLayerCountWithFallback,
   getContextLengthWithFallback,
+  hasGGUFMetadata,
 } from '../utils/model-metadata-helpers.js';
+import { estimateKVBytesPerToken } from '../utils/kv-cache-math.js';
 
 /**
  * System information singleton
@@ -181,15 +185,23 @@ export class SystemInfo {
   }> {
     const capabilities = await this.detect();
 
-    // When GPU layers are specified, only the CPU portion needs to fit in RAM
+    // Floor-context KV cost (real arithmetic when GGUF metadata is present;
+    // models without metadata keep the legacy weights-only estimate)
+    const kvFloorBytes =
+      hasGGUFMetadata(modelInfo) && modelInfo.ggufMetadata?.block_count
+        ? KV_SIZING.floorContextTokens * estimateKVBytesPerToken(modelInfo)
+        : 0;
+
+    // When GPU layers are specified, only the CPU portion (weights + its KV
+    // share) needs to fit in RAM
     const gpuLayers = options?.gpuLayers;
     let requiredMemory: number;
     if (gpuLayers && gpuLayers > 0) {
       const totalLayers = options?.totalLayers ?? getLayerCountWithFallback(modelInfo);
       const cpuRatio = Math.max(0, 1 - gpuLayers / totalLayers);
-      requiredMemory = modelInfo.size * cpuRatio * 1.2;
+      requiredMemory = (modelInfo.size * 1.2 + kvFloorBytes) * cpuRatio;
     } else {
-      requiredMemory = modelInfo.size * 1.2; // 20% overhead
+      requiredMemory = modelInfo.size * 1.2 + kvFloorBytes; // 20% overhead + KV floor
     }
 
     // Get fresh memory info (not cached) for accurate availability check
@@ -237,32 +249,134 @@ export class SystemInfo {
    * console.log(`Use ${config.threads} threads and ${config.gpuLayers} GPU layers`);
    * ```
    */
-  public async getOptimalConfig(modelInfo: ModelInfo): Promise<Partial<ServerConfig>> {
+  public async getOptimalConfig(
+    modelInfo: ModelInfo,
+    hints: OptimalConfigHints = {}
+  ): Promise<Partial<LlamaServerConfig>> {
     const capabilities = await this.detect();
 
-    // Get fresh memory info (not cached) for accurate context size calculation
+    // Get fresh memory info (not cached) for accurate sizing
     const currentMemory = this.getMemoryInfo();
 
-    // Use GGUF context length if available, otherwise fall back to recommendation
-    const contextLength = getContextLengthWithFallback(modelInfo);
-    const contextSize = Math.min(
-      contextLength,
-      this.recommendContextSize(currentMemory.available, modelInfo.size)
-    );
-
-    const config: Partial<ServerConfig> = {
+    const config: Partial<LlamaServerConfig> = {
       threads: getRecommendedThreads(capabilities.cpu.cores),
-      contextSize,
-      parallelRequests: this.recommendParallelRequests(capabilities.cpu.cores),
+      parallelRequests: hints.parallelRequests ?? this.recommendParallelRequests(),
     };
 
-    // Add GPU layers if GPU is available
-    if (capabilities.gpu.available && capabilities.gpu.vram) {
-      // Use actual layer count from GGUF metadata (or fallback to estimation)
-      const actualLayers = getLayerCountWithFallback(modelInfo);
-      config.gpuLayers = calculateGPULayers(actualLayers, capabilities.gpu.vram, modelInfo.size);
+    const modelCtx = getContextLengthWithFallback(modelInfo);
+    const totalLayers = getLayerCountWithFallback(modelInfo);
+    const gpu = capabilities.gpu;
+    const hasVRAM = gpu.available && !!gpu.vram;
+
+    // Legacy path when GGUF metadata is missing: previous behavior exactly
+    // (fixed 4096 context, flat-reserve layer packing, no cache recommendation)
+    if (!hasGGUFMetadata(modelInfo) || !modelInfo.ggufMetadata?.block_count) {
+      config.contextSize = hints.contextSize ?? Math.min(modelCtx, KV_SIZING.floorContextTokens);
+      config.gpuLayers =
+        hints.gpuLayers ??
+        (hasVRAM ? calculateGPULayers(totalLayers, gpu.vram!, modelInfo.size) : 0);
+      return config;
+    }
+
+    // --- KV-aware sizing ---
+    const floor = KV_SIZING.floorContextTokens;
+    const clampCtx = (tokens: number): number => {
+      const rounded =
+        Math.floor(tokens / KV_SIZING.contextGranularityTokens) *
+        KV_SIZING.contextGranularityTokens;
+      return Math.max(floor, Math.min(modelCtx, rounded));
+    };
+
+    const weightsGPU = modelInfo.size * KV_SIZING.gpuWeightsOverhead;
+    const vramBudget = hasVRAM
+      ? Math.max(0, (gpu.vramAvailable ?? gpu.vram!) - KV_SIZING.computeBufferBytes)
+      : 0;
+    const cpuContext = (bytesPerToken: number): number =>
+      clampCtx(
+        (currentMemory.available -
+          modelInfo.size * KV_SIZING.cpuWeightsOverhead -
+          KV_SIZING.osRamMarginBytes) /
+          bytesPerToken
+      );
+
+    // 1. Choose KV cache types. Default policy: q8_0 (small quality loss,
+    // ~2x cheaper KV) unless f16 KV at the model's FULL native context fits
+    // alongside fully-offloaded weights ("abundant headroom"). Explicit user
+    // cache types always win; explicit flashAttention off suppresses
+    // quantization (quantized V requires flash attention); CPU-only stays f16.
+    const userPinnedCacheType = hints.cacheTypeK !== undefined || hints.cacheTypeV !== undefined;
+    const flashAttentionOff = hints.flashAttention === 'off' || hints.flashAttention === false;
+    let cacheTypeK: KVCacheType = hints.cacheTypeK ?? 'f16';
+    let cacheTypeV: KVCacheType = hints.cacheTypeV ?? 'f16';
+    let autoQuantized = false;
+
+    if (!userPinnedCacheType && !flashAttentionOff && hasVRAM && vramBudget > 0) {
+      const bptF16 = estimateKVBytesPerToken(modelInfo, 'f16', 'f16');
+      const abundantHeadroom = weightsGPU + modelCtx * bptF16 <= vramBudget;
+      if (!abundantHeadroom) {
+        cacheTypeK = 'q8_0';
+        cacheTypeV = 'q8_0';
+        autoQuantized = true;
+      }
+    }
+
+    const bpt = estimateKVBytesPerToken(modelInfo, cacheTypeK, cacheTypeV);
+
+    // 2. Offload + context. Full GPU offload is the prize: the KV reserve
+    // flexes down to the floor-context cost to win it; when full offload is
+    // impossible, fall back to packing layers around a KV reserve.
+    let gpuLayers: number;
+    let contextTokens: number;
+
+    if (hasVRAM && vramBudget > 0) {
+      const pinnedCtx = hints.contextSize;
+      const requiredKV = (pinnedCtx ?? floor) * bpt;
+      const fullOffloadFits = weightsGPU + requiredKV <= vramBudget;
+
+      if (hints.gpuLayers !== undefined ? hints.gpuLayers >= totalLayers : fullOffloadFits) {
+        // Full offload: all leftover VRAM becomes context budget
+        gpuLayers = hints.gpuLayers ?? totalLayers;
+        contextTokens = pinnedCtx ?? clampCtx((vramBudget - weightsGPU) / bpt);
+      } else {
+        // Partial offload: reserve KV (at least the floor's worth), pack layers
+        const reserve = Math.max(requiredKV, KV_SIZING.minPartialReserveBytes);
+        const perLayer = weightsGPU / totalLayers;
+        gpuLayers =
+          hints.gpuLayers ??
+          Math.min(totalLayers, Math.max(0, Math.floor((vramBudget - reserve) / perLayer)));
+
+        if (gpuLayers <= 0) {
+          gpuLayers = 0;
+          contextTokens = pinnedCtx ?? cpuContext(bpt);
+        } else {
+          // Context bounded by BOTH the GPU-side KV share and the RAM-side share
+          const gpuShare = gpuLayers / totalLayers;
+          const cpuShare = 1 - gpuShare;
+          const gpuKVBudget = Math.max(0, vramBudget - gpuLayers * perLayer);
+          const ramKVBudget = Math.max(
+            0,
+            currentMemory.available -
+              modelInfo.size * cpuShare * KV_SIZING.cpuWeightsOverhead -
+              KV_SIZING.osRamMarginBytes
+          );
+          const byGPU = gpuShare > 0 ? gpuKVBudget / (bpt * gpuShare) : Infinity;
+          const byRAM = cpuShare > 0 ? ramKVBudget / (bpt * cpuShare) : Infinity;
+          contextTokens = pinnedCtx ?? clampCtx(Math.min(byGPU, byRAM));
+        }
+      }
     } else {
-      config.gpuLayers = 0; // CPU-only
+      gpuLayers = hints.gpuLayers ?? 0;
+      contextTokens = hints.contextSize ?? cpuContext(bpt);
+    }
+
+    config.contextSize = contextTokens;
+    config.gpuLayers = gpuLayers;
+    if (autoQuantized) {
+      config.cacheTypeK = cacheTypeK;
+      config.cacheTypeV = cacheTypeV;
+      // Quantized V-cache requires flash attention; make the recommendation
+      // self-consistent (LlamaServerManager enforces the same constraint)
+      config.flashAttention = 'on';
     }
 
     return config;
@@ -313,28 +427,6 @@ export class SystemInfo {
   }
 
   /**
-   * Recommend context size based on available memory
-   *
-   * IMPORTANT: This is a placeholder implementation that uses llama.cpp's default (4096).
-   * The previous RAM-based calculation was overly conservative and didn't consider VRAM.
-   *
-   * TODO: Implement proper VRAM-aware context size calculation:
-   * - For GPU inference, calculate based on available VRAM (not RAM)
-   * - Consider KV cache size: approximately 1-2MB per token depending on model architecture
-   * - Account for model layers already loaded in VRAM
-   * - Leave adequate VRAM buffer for inference operations
-   * - For CPU-only inference, consider RAM but with better estimates
-   *
-   * For now, we use llama.cpp's default which provides good balance for most use cases.
-   * Users can override via the `contextSize` parameter in ServerConfig if needed.
-   */
-  private recommendContextSize(_availableRAM: number, _modelSize: number): number {
-    // Use llama.cpp's default context size
-    // This provides good performance for most models without being overly conservative
-    return 4096;
-  }
-
-  /**
    * Recommend parallel request slots
    *
    * Returns 1 for single-user Electron apps. The KV cache is shared across all parallel
@@ -344,10 +436,9 @@ export class SystemInfo {
    * Multi-user server deployments should explicitly set parallelRequests based on expected
    * concurrent load rather than relying on this auto-configuration.
    *
-   * @param _cpuCores - Number of CPU cores (unused, kept for interface consistency)
    * @returns Recommended number of parallel request slots (always 1 for single-user apps)
    */
-  private recommendParallelRequests(_cpuCores: number): number {
+  private recommendParallelRequests(): number {
     // Always return 1 for single-user Electron apps
     // The previous CPU-based logic (8 for 16+ cores) was designed for multi-user servers
     // and caused issues where KV cache was split across slots, limiting per-request tokens

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export type {
   ServerEvent,
   ServerEventData,
   BinaryLogEvent,
+  OptimalConfigHints,
 } from './servers.js';
 
 // Image generation types

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -120,6 +120,12 @@ export interface GGUFMetadata {
   /** Number of attention heads */
   attention_head_count?: number;
 
+  /** Number of KV heads (GQA models have fewer than attention_head_count) */
+  attention_head_count_kv?: number;
+
+  /** Per-head key dimension (set when it differs from embedding_length / head_count) */
+  attention_key_length?: number;
+
   /** Embedding dimension length */
   embedding_length?: number;
 

--- a/src/types/servers.ts
+++ b/src/types/servers.ts
@@ -230,6 +230,25 @@ export interface LlamaServerConfig extends ServerConfig {
 }
 
 /**
+ * Hints for SystemInfo.getOptimalConfig(): fields the caller has already
+ * pinned. Pinned values are respected verbatim and inform the sizing of the
+ * remaining dimensions (e.g. a pinned contextSize shapes the KV reserve used
+ * for GPU-layer packing; explicit cache types or flashAttention: 'off'
+ * suppress automatic KV quantization).
+ */
+export type OptimalConfigHints = Partial<
+  Pick<
+    LlamaServerConfig,
+    | 'contextSize'
+    | 'gpuLayers'
+    | 'parallelRequests'
+    | 'flashAttention'
+    | 'cacheTypeK'
+    | 'cacheTypeV'
+  >
+>;
+
+/**
  * Server event types
  */
 export type ServerEvent =

--- a/src/utils/kv-cache-math.ts
+++ b/src/utils/kv-cache-math.ts
@@ -1,0 +1,70 @@
+/**
+ * KV-cache memory arithmetic
+ *
+ * Estimates the per-token KV-cache cost of a model from its GGUF metadata,
+ * used by SystemInfo's adaptive context/offload recommendations and the
+ * ResourceOrchestrator's memory estimates.
+ *
+ * GQA-correctness matters: modern models have far fewer KV heads than
+ * attention heads (attention.head_count_kv), and using the full head count
+ * would overestimate KV cost by 4-8x.
+ *
+ * @module utils/kv-cache-math
+ */
+
+import type { KVCacheType, ModelInfo } from '../types/index.js';
+import {
+  getLayerCountWithFallback,
+  getKVHeadCountWithFallback,
+  getHeadDimensionWithFallback,
+} from './model-metadata-helpers.js';
+
+/**
+ * Bytes per KV-cache element by cache type, following llama.cpp's block
+ * layouts (block bytes / 32 elements for the quantized types).
+ */
+export const KV_CACHE_BYTES_PER_ELEMENT: Record<KVCacheType, number> = {
+  f16: 2,
+  bf16: 2,
+  q8_0: 34 / 32,
+  q5_0: 22 / 32,
+  q5_1: 24 / 32,
+  q4_0: 18 / 32,
+  q4_1: 20 / 32,
+  iq4_nl: 18 / 32,
+};
+
+/**
+ * Estimate the KV-cache cost of ONE context token, in bytes
+ *
+ * Formula: layers x kvHeads x headDim x (bytes(K) + bytes(V)).
+ * Uses GGUF metadata with conservative fallbacks (MHA head count when
+ * head_count_kv is absent), so the estimate errs high, never low.
+ *
+ * Note: sliding-window models (e.g. Gemma) are priced as full-attention,
+ * which overestimates their effective KV cost — conservative by design.
+ *
+ * @param modelInfo - Model information (ggufMetadata preferred)
+ * @param cacheTypeK - K-cache quantization (default: f16, llama.cpp's default)
+ * @param cacheTypeV - V-cache quantization (default: f16)
+ * @returns Estimated bytes of KV cache per context token
+ *
+ * @example
+ * ```typescript
+ * const bytesPerToken = estimateKVBytesPerToken(modelInfo, 'q8_0', 'q8_0');
+ * const kvFor32K = 32768 * bytesPerToken;
+ * ```
+ */
+export function estimateKVBytesPerToken(
+  modelInfo: ModelInfo,
+  cacheTypeK: KVCacheType = 'f16',
+  cacheTypeV: KVCacheType = 'f16'
+): number {
+  const layers = getLayerCountWithFallback(modelInfo);
+  const kvHeads = getKVHeadCountWithFallback(modelInfo);
+  const headDim = getHeadDimensionWithFallback(modelInfo);
+  const bytesPerElement =
+    KV_CACHE_BYTES_PER_ELEMENT[cacheTypeK] + KV_CACHE_BYTES_PER_ELEMENT[cacheTypeV];
+
+  return layers * kvHeads * headDim * bytesPerElement;
+}

--- a/src/utils/model-metadata-helpers.ts
+++ b/src/utils/model-metadata-helpers.ts
@@ -155,6 +155,66 @@ export function getAttentionHeadCountWithFallback(modelInfo: ModelInfo): number 
 }
 
 /**
+ * Get KV-head count (GQA) with fallback
+ *
+ * Priority:
+ * 1. Typed GGUF field (attention_head_count_kv)
+ * 2. Raw metadata lookup (models downloaded before this field was extracted)
+ * 3. Full attention head count — the MHA assumption, which OVERESTIMATES the
+ *    KV cost of GQA models and is therefore a safe (conservative) fallback
+ *
+ * @param modelInfo - Model information
+ * @returns KV-head count (actual or conservative fallback)
+ */
+export function getKVHeadCountWithFallback(modelInfo: ModelInfo): number {
+  const meta = modelInfo.ggufMetadata;
+  if (meta?.attention_head_count_kv) {
+    return meta.attention_head_count_kv;
+  }
+
+  const arch = meta?.architecture;
+  if (arch && meta?.raw) {
+    const value = meta.raw[`${arch}.attention.head_count_kv`];
+    if (typeof value === 'number' && value > 0) {
+      return value;
+    }
+  }
+
+  return getAttentionHeadCountWithFallback(modelInfo);
+}
+
+/**
+ * Get per-head key dimension with fallback
+ *
+ * Priority:
+ * 1. Typed GGUF field (attention_key_length — set when it differs from the
+ *    conventional embedding_length / head_count, e.g. some Gemma models)
+ * 2. Raw metadata lookup
+ * 3. embedding_length / attention_head_count
+ *
+ * @param modelInfo - Model information
+ * @returns Head dimension in elements
+ */
+export function getHeadDimensionWithFallback(modelInfo: ModelInfo): number {
+  const meta = modelInfo.ggufMetadata;
+  if (meta?.attention_key_length) {
+    return meta.attention_key_length;
+  }
+
+  const arch = meta?.architecture;
+  if (arch && meta?.raw) {
+    const value = meta.raw[`${arch}.attention.key_length`];
+    if (typeof value === 'number' && value > 0) {
+      return value;
+    }
+  }
+
+  return Math.round(
+    getEmbeddingLengthWithFallback(modelInfo) / getAttentionHeadCountWithFallback(modelInfo)
+  );
+}
+
+/**
  * Get embedding length from model info with fallback to estimation
  *
  * Priority:

--- a/tests/unit/LlamaServerManager.test.ts
+++ b/tests/unit/LlamaServerManager.test.ts
@@ -1103,5 +1103,84 @@ describe('LlamaServerManager', () => {
       expect(gpuLayersIndex).toBeGreaterThan(-1);
       expect(args[gpuLayersIndex + 1]).toBe('0');
     });
+
+    it('should forward user config as hints to getOptimalConfig', async () => {
+      await llamaServer.start({
+        ...mockConfig,
+        contextSize: 16384,
+        cacheTypeK: 'f16',
+        flashAttention: 'off',
+      });
+
+      expect(mockSystemInfo.getOptimalConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          contextSize: 16384,
+          cacheTypeK: 'f16',
+          flashAttention: 'off',
+        })
+      );
+    });
+
+    it('should emit auto-recommended KV quantization flags', async () => {
+      mockSystemInfo.getOptimalConfig.mockResolvedValue({
+        threads: 7,
+        contextSize: 65536,
+        gpuLayers: 36,
+        parallelRequests: 1,
+        cacheTypeK: 'q8_0',
+        cacheTypeV: 'q8_0',
+        flashAttention: 'on',
+      });
+
+      await llamaServer.start(mockConfig);
+
+      const args = mockProcessSpawn.mock.calls[0][1] as string[];
+      const val = (flag: string) => args[args.indexOf(flag) + 1];
+      expect(val('--cache-type-k')).toBe('q8_0');
+      expect(val('--cache-type-v')).toBe('q8_0');
+      expect(val('-fa')).toBe('on');
+      expect(val('-c')).toBe('65536');
+    });
+
+    it('should prefer user cache types over auto-recommendations', async () => {
+      mockSystemInfo.getOptimalConfig.mockResolvedValue({
+        threads: 7,
+        contextSize: 65536,
+        gpuLayers: 36,
+        parallelRequests: 1,
+        cacheTypeK: 'q8_0',
+        cacheTypeV: 'q8_0',
+        flashAttention: 'on',
+      });
+
+      await llamaServer.start({ ...mockConfig, cacheTypeK: 'f16', cacheTypeV: 'f16' });
+
+      const args = mockProcessSpawn.mock.calls[0][1] as string[];
+      const val = (flag: string) => args[args.indexOf(flag) + 1];
+      expect(val('--cache-type-k')).toBe('f16');
+      expect(val('--cache-type-v')).toBe('f16');
+    });
+
+    it('should not apply auto cache recommendations when fit is on', async () => {
+      mockSystemInfo.getOptimalConfig.mockResolvedValue({
+        threads: 7,
+        contextSize: 65536,
+        gpuLayers: 36,
+        parallelRequests: 1,
+        cacheTypeK: 'q8_0',
+        cacheTypeV: 'q8_0',
+        flashAttention: 'on',
+      });
+
+      await llamaServer.start({ ...mockConfig, fit: 'on' });
+
+      const args = mockProcessSpawn.mock.calls[0][1] as string[];
+      expect(args).not.toContain('--cache-type-k');
+      expect(args).not.toContain('--cache-type-v');
+      expect(args).not.toContain('-fa');
+      expect(args).not.toContain('-c');
+      expect(args).not.toContain('-ngl');
+    });
   });
 });

--- a/tests/unit/SystemInfo.test.ts
+++ b/tests/unit/SystemInfo.test.ts
@@ -338,6 +338,149 @@ describe('SystemInfo', () => {
 
       expect(config.gpuLayers).toBe(0);
     });
+
+    it('should keep the legacy 4096 context for models without GGUF metadata', async () => {
+      const config = await systemInfo.getOptimalConfig({
+        id: 'test-model',
+        name: 'Test Model',
+        type: 'llm',
+        size: 4 * 1024 * 1024 * 1024,
+        path: '/test/path',
+        downloadedAt: new Date().toISOString(),
+        source: { type: 'url', url: 'http://test.com' },
+      });
+
+      expect(config.contextSize).toBe(4096);
+      expect(config.cacheTypeK).toBeUndefined();
+      expect(config.cacheTypeV).toBeUndefined();
+    });
+  });
+
+  describe('getOptimalConfig() — KV-aware sizing', () => {
+    // RTX 3080 mock from the shared beforeEach: 10 GiB total, ~9.28 GiB free
+    const makeModel = (
+      overrides: Partial<import('../../src/types/index.js').ModelInfo> = {},
+      meta: Partial<NonNullable<import('../../src/types/index.js').ModelInfo['ggufMetadata']>> = {}
+    ): import('../../src/types/index.js').ModelInfo => ({
+      id: 'kv-model',
+      name: 'KV Model',
+      type: 'llm',
+      size: 2.4 * 1024 ** 3,
+      path: '/test/kv.gguf',
+      downloadedAt: new Date().toISOString(),
+      source: { type: 'url', url: 'http://test.com' },
+      ggufMetadata: {
+        architecture: 'qwen3',
+        block_count: 36,
+        attention_head_count: 32,
+        attention_head_count_kv: 8,
+        attention_key_length: 128,
+        embedding_length: 4096,
+        context_length: 262144,
+        ...meta,
+      },
+      ...overrides,
+    });
+
+    const gpuCapabilities = {
+      cpu: { cores: 8, model: 'Test CPU', architecture: 'x64' },
+      memory: { total: 16 * 1024 ** 3, available: 8 * 1024 ** 3, used: 8 * 1024 ** 3 },
+      gpu: {
+        available: true,
+        type: 'nvidia' as const,
+        name: 'RTX 3080',
+        vram: 10 * 1024 ** 3,
+        vramAvailable: 9.28 * 1024 ** 3,
+        cuda: true,
+      },
+      platform: 'linux' as const,
+      recommendations: {
+        maxModelSize: '13B',
+        recommendedQuantization: ['Q4_K_M'],
+        threads: 7,
+        gpuAcceleration: true,
+      },
+    };
+
+    beforeEach(() => {
+      // Deterministic capabilities (exec-based GPU detection doesn't survive
+      // promisify with a plain mocked exec)
+      jest.spyOn(systemInfo, 'detect').mockResolvedValue(gpuCapabilities as never);
+    });
+
+    it('auto-selects q8_0 KV + flash attention for a long-context model and grows context', async () => {
+      const config = await systemInfo.getOptimalConfig(makeModel());
+
+      // Full offload (2.4 GB model easily fits)
+      expect(config.gpuLayers).toBe(36);
+      // q8_0 chosen: f16 KV at 256K native context is nowhere near fitting
+      expect(config.cacheTypeK).toBe('q8_0');
+      expect(config.cacheTypeV).toBe('q8_0');
+      expect(config.flashAttention).toBe('on');
+      // Context far beyond the old 4096 constant, rounded to 1024
+      expect(config.contextSize!).toBeGreaterThan(32768);
+      expect(config.contextSize! % 1024).toBe(0);
+      expect(config.contextSize!).toBeLessThanOrEqual(262144);
+    });
+
+    it('keeps f16 KV when headroom is abundant (small native context)', async () => {
+      const config = await systemInfo.getOptimalConfig(makeModel({}, { context_length: 4096 }));
+
+      expect(config.gpuLayers).toBe(36);
+      expect(config.cacheTypeK).toBeUndefined();
+      expect(config.cacheTypeV).toBeUndefined();
+      expect(config.flashAttention).toBeUndefined();
+      expect(config.contextSize).toBe(4096); // capped by the model itself
+    });
+
+    it('respects explicit cache-type hints (no auto-quantization)', async () => {
+      const config = await systemInfo.getOptimalConfig(makeModel(), { cacheTypeK: 'f16' });
+
+      expect(config.cacheTypeK).toBeUndefined(); // caller already owns the field
+      expect(config.cacheTypeV).toBeUndefined();
+      expect(config.flashAttention).toBeUndefined();
+      expect(config.contextSize!).toBeGreaterThanOrEqual(4096);
+    });
+
+    it('suppresses auto-quantization when flash attention is explicitly off', async () => {
+      const config = await systemInfo.getOptimalConfig(makeModel(), { flashAttention: 'off' });
+
+      expect(config.cacheTypeK).toBeUndefined();
+      expect(config.cacheTypeV).toBeUndefined();
+      expect(config.flashAttention).toBeUndefined();
+    });
+
+    it('partially offloads oversized models and falls back toward the context floor', async () => {
+      const big = makeModel({ size: 12 * 1024 ** 3 }, { block_count: 48, context_length: 131072 });
+      const config = await systemInfo.getOptimalConfig(big);
+
+      expect(config.gpuLayers!).toBeGreaterThan(0);
+      expect(config.gpuLayers!).toBeLessThan(48);
+      // RAM side is the binding constraint on this 16 GB mock machine
+      expect(config.contextSize).toBe(4096);
+    });
+
+    it('respects a pinned contextSize and sizes layers around its KV cost', async () => {
+      const config = await systemInfo.getOptimalConfig(makeModel(), { contextSize: 16384 });
+
+      expect(config.contextSize).toBe(16384);
+      expect(config.gpuLayers).toBe(36); // still fits fully alongside 16K of KV
+    });
+
+    it('sizes context from RAM on CPU-only systems and keeps f16', async () => {
+      jest.spyOn(systemInfo, 'detect').mockResolvedValue({
+        ...gpuCapabilities,
+        gpu: { available: false },
+      } as never);
+
+      const config = await systemInfo.getOptimalConfig(makeModel());
+
+      expect(config.gpuLayers).toBe(0);
+      expect(config.cacheTypeK).toBeUndefined();
+      // 8 GiB free - 2.88 weights - 2 margin = ~3.1 GiB / 144 KiB per token
+      expect(config.contextSize!).toBeGreaterThan(4096);
+      expect(config.contextSize! % 1024).toBe(0);
+    });
   });
 
   describe('Platform-specific detection', () => {

--- a/tests/unit/kv-cache-math.test.ts
+++ b/tests/unit/kv-cache-math.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for KV-cache memory arithmetic
+ */
+
+import {
+  estimateKVBytesPerToken,
+  KV_CACHE_BYTES_PER_ELEMENT,
+} from '../../src/utils/kv-cache-math.js';
+import type { ModelInfo } from '../../src/types/index.js';
+
+const baseModel = (ggufMetadata?: ModelInfo['ggufMetadata']): ModelInfo => ({
+  id: 'm',
+  name: 'M',
+  type: 'llm',
+  size: 4 * 1024 ** 3,
+  path: '/m.gguf',
+  downloadedAt: '2026-07-03T00:00:00Z',
+  source: { type: 'url', url: 'https://x/m.gguf' },
+  ggufMetadata,
+});
+
+describe('kv-cache-math', () => {
+  it('computes f16 KV bytes/token for a GQA model (typed fields)', () => {
+    const model = baseModel({
+      architecture: 'qwen3',
+      block_count: 36,
+      attention_head_count: 32,
+      attention_head_count_kv: 8,
+      attention_key_length: 128,
+      embedding_length: 4096,
+      context_length: 262144,
+    });
+
+    // 36 layers x 8 KV heads x 128 dim x (2 + 2) bytes
+    expect(estimateKVBytesPerToken(model)).toBe(36 * 8 * 128 * 4);
+  });
+
+  it('falls back to MHA head count when head_count_kv is absent (conservative)', () => {
+    const model = baseModel({
+      architecture: 'llama',
+      block_count: 32,
+      attention_head_count: 32,
+      embedding_length: 4096,
+      context_length: 4096,
+    });
+
+    // headDim = 4096/32 = 128; MHA: kvHeads = 32
+    expect(estimateKVBytesPerToken(model)).toBe(32 * 32 * 128 * 4);
+  });
+
+  it('reads head_count_kv from raw metadata for older downloads', () => {
+    const model = baseModel({
+      architecture: 'llama',
+      block_count: 32,
+      attention_head_count: 32,
+      embedding_length: 4096,
+      context_length: 8192,
+      raw: { 'llama.attention.head_count_kv': 8 },
+    });
+
+    expect(estimateKVBytesPerToken(model)).toBe(32 * 8 * 128 * 4);
+  });
+
+  it('halves-ish the cost with q8_0 K and V', () => {
+    const model = baseModel({
+      architecture: 'qwen3',
+      block_count: 36,
+      attention_head_count: 32,
+      attention_head_count_kv: 8,
+      attention_key_length: 128,
+      context_length: 262144,
+    });
+
+    const f16 = estimateKVBytesPerToken(model, 'f16', 'f16');
+    const q8 = estimateKVBytesPerToken(model, 'q8_0', 'q8_0');
+    expect(q8).toBeCloseTo(f16 * (KV_CACHE_BYTES_PER_ELEMENT.q8_0 / 2), 5);
+    expect(q8).toBeLessThan(f16 * 0.6);
+  });
+
+  it('supports mixed K/V cache types', () => {
+    const model = baseModel({
+      architecture: 'qwen3',
+      block_count: 10,
+      attention_head_count_kv: 4,
+      attention_head_count: 16,
+      attention_key_length: 64,
+      context_length: 4096,
+    });
+
+    const mixed = estimateKVBytesPerToken(model, 'f16', 'q4_0');
+    expect(mixed).toBe(10 * 4 * 64 * (2 + 18 / 32));
+  });
+
+  it('produces a finite positive estimate without any metadata (size fallback)', () => {
+    const model = baseModel(undefined);
+    const bpt = estimateKVBytesPerToken(model);
+    expect(bpt).toBeGreaterThan(0);
+    expect(Number.isFinite(bpt)).toBe(true);
+  });
+});


### PR DESCRIPTION
Resolves `docs/dev/issues/ISSUE-context-size-recommendation.md` (filed from palimpsest-engine integration): the `recommendContextSize` stub pinned every auto-configured server at a 4096-token context regardless of hardware, silently truncating long prompts.

**Upgrade guide:** [migration-0-6-to-0-7.md](https://github.com/lacerbi/genai-electron/blob/feat/v0.7.0-adaptive-context/genai-electron-docs/migration-0-6-to-0-7.md)

## What changes (auto-configured servers only — explicit config always wins)
- **Adaptive context sizing** from real KV-cache arithmetic (`layers × kvHeads × headDim × bytes/element`, GQA-aware via `attention.head_count_kv`, honors per-head `key_length`). No artificial ceiling — capped only by the model's own `context_length`.
- **Full-GPU-offload preference**: the old flat 2 GB KV reserve could push almost-fitting models into partial offload (a large perf cliff); the reserve now flexes down to the 4096-token floor to win full offload.
- **Automatic q8_0 KV quantization** (+ flash attention on) by default, unless f16 KV at the model's full native context fits alongside fully-offloaded weights. Opt out: `cacheTypeK/V: 'f16'` or `flashAttention: 'off'`.
- `getOptimalConfig(modelInfo, hints?)` — pinned fields (contextSize, gpuLayers, cache types, FA) shape the remaining recommendations; returns `Partial<LlamaServerConfig>`.
- KV-aware `canRunModel()` and ResourceOrchestrator estimates. Models without GGUF metadata keep the exact legacy behavior.
- New exports: `estimateKVBytesPerToken`, `KV_CACHE_BYTES_PER_ELEMENT`, `KV_SIZING`, `OptimalConfigHints`.

## Why minor, not patch
New public API (semver), and at 0.x the minor slot is the caret-range opt-in boundary — auto-configured servers now allocate significantly more VRAM (larger KV) and quantize KV by default, which `^0.6.x` consumers should opt into, not absorb silently.

## Verification
- 506/506 tests (21 suites), 0 TS errors, lint clean.
- **Live GPU smoke** (pure auto-config, Qwen3.5-4B): `-ngl 32` full offload, auto `q8_0` KV + `-fa on`, **context 58368** (was 4096) confirmed via `/props`; an **8130-token prompt** round-tripped with a secret planted at the prompt start correctly retrieved — the exact failure mode from the issue, gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f