### PR TITLE
fix: use readonly T[] array syntax per lint rules (CI Code Quality)

### DIFF
--- a/src/utils/kv-cache-math.ts
+++ b/src/utils/kv-cache-math.ts
@@ -39,7 +39,7 @@ export const KV_CACHE_BYTES_PER_ELEMENT: Record<KVCacheType, number> = {
  * Rounding stays proportional to scale (roughly within 6% of the value)
  * while producing "round" context sizes at every magnitude.
  */
-export const CONTEXT_GRANULARITY_LADDER: ReadonlyArray<readonly [number, number]> = [
+export const CONTEXT_GRANULARITY_LADDER: readonly (readonly [number, number])[] = [
   [2048, 128],
   [4096, 256],
   [8192, 512],


### PR DESCRIPTION
Fixes the Code Quality CI failure from #26: `ReadonlyArray<T>` → `readonly T[]` per the repo's @typescript-eslint/array-type rule. Type-level only; 514/514 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f