### PR TITLE
test: cover the orchestrator's MoE weight-split estimates directly

### DIFF
--- a/ISSUE-binary-progress-event.md
+++ b/ISSUE-binary-progress-event.md
@@ -1,0 +1,59 @@
+# ISSUE: Structured progress event for binary provisioning (downloads currently parseable only from log strings)
+
+Created: 2026-07-03
+Status: OPEN
+Package: genai-electron (filed from palimpsest-engine loading-UI work)
+
+## Problem
+
+The first `llamaServer.start()` downloads the llama.cpp binary (~50–300 MB) —
+a long, silent wait from the consumer app's perspective. The only signal is
+the `'binary-log'` event, whose payload is a human-readable string:
+`BinaryManager` logs `` `Downloading ${variant.type} binary: ${percent}%` ``
+(src/managers/BinaryManager.ts, main-binary and dependency download
+callbacks) through the `log` callback that `ServerManager.emit('binary-log',
+{ message, level })` forwards.
+
+Consumers who want a progress bar must regex the percentage out of the
+message text. palimpsest does exactly this today
+(`/:\s*(\d+(?:\.\d+)?)%\s*$/` on `binary-log` messages) and it works — but
+the message wording is now an implicit API contract: any rephrasing of the
+log line silently breaks downstream progress UIs. (Same failure class as the
+Gemini timeout message-sniffing that v0.9.2 of genai-lite just eliminated.)
+
+Two smaller papercuts from the same gap:
+
+- The log fires on **every download chunk**, so consumers must also throttle.
+- There's no machine-readable phase signal (downloading vs. verifying vs.
+  variant testing) — only prose.
+
+## Fix
+
+Add a structured event alongside `binary-log` (which stays as-is for
+logging), e.g.:
+
+```typescript
+// ServerEvent union += 'binary-progress'
+export interface BinaryProgressEvent {
+  phase: 'downloading' | 'extracting' | 'verifying' | 'testing';
+  /** What is being downloaded: 'binary' or a dependency description */
+  file: string;
+  downloaded?: number;  // bytes, when phase === 'downloading'
+  total?: number;       // bytes, when known
+}
+```
+
+Emit from the same `onProgress` callbacks that currently produce the log
+lines (BinaryManager already has `downloaded`/`total` in hand), throttled at
+the source (e.g. whole-percent changes), plus one event per phase
+transition. This mirrors the precedent of `DownloadProgressCallback` on
+`modelManager.downloadModel()` — model downloads already give consumers
+structured bytes; binary downloads should too.
+
+## Notes
+
+- Severity: low — a log-parsing workaround exists and ships in palimpsest;
+  this is about removing an implicit string contract before more consumers
+  grow to depend on it.
+- If the event lands, palimpsest drops its regex + throttle and subscribes
+  to `binary-progress` directly.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@
 ## Current Build Status
 
 - **Build:** ✅ 0 TypeScript errors
-- **Tests:** ✅ 532/532 passing (21 suites)
+- **Tests:** ✅ 536/536 passing (21 suites)
 - **Branch:** `main`
 - **Last Updated:** 2026-07-03 (v0.6.1: security patch — npm audit clean, tar minimum ^7.5.19)
 

--- a/tests/unit/ResourceOrchestrator.test.ts
+++ b/tests/unit/ResourceOrchestrator.test.ts
@@ -22,6 +22,7 @@ jest.unstable_mockModule('../../src/system/SystemInfo.js', () => ({
 // Mock ModelManager
 const mockModelManager = {
   getModelInfo: jest.fn(),
+  getModelLayerCount: jest.fn(),
 };
 
 jest.unstable_mockModule('../../src/managers/ModelManager.js', () => ({
@@ -101,6 +102,12 @@ describe('ResourceOrchestrator', () => {
       if (modelId === 'llama-2-7b') return Promise.resolve(llmModelInfo);
       if (modelId === 'sdxl-turbo') return Promise.resolve(diffusionModelInfo);
       return Promise.reject(new Error('Model not found'));
+    });
+    // Default: layer count unavailable → estimateLLMUsage falls back to its
+    // conservative default estimates (the pre-existing behavior these tests
+    // were written against). MoE tests below override this.
+    mockModelManager.getModelLayerCount.mockImplementation(() => {
+      throw new Error('layer count not mocked');
     });
 
     mockLlamaServer.isRunning.mockReturnValue(false);
@@ -607,6 +614,81 @@ describe('ResourceOrchestrator', () => {
       const needsOffload = await orchestrator.wouldNeedOffload();
 
       expect(needsOffload).toBe(true);
+    });
+  });
+
+  describe('estimateLLMUsage() — MoE split', () => {
+    const GiB = 1024 ** 3;
+    const moeModelInfo = {
+      ...llmModelInfo,
+      id: 'moe-26b',
+      size: 12 * GiB,
+      // No block_count: KV term stays 0, isolating the weights arithmetic
+      ggufMetadata: { expert_count: 128, expert_weights_bytes: 10 * GiB },
+    };
+    type UsageProbe = { estimateLLMUsage(): Promise<{ ram: number; vram?: number }> };
+    const estimate = () => (orchestrator as unknown as UsageProbe).estimateLLMUsage();
+
+    beforeEach(() => {
+      mockLlamaServer.isRunning.mockReturnValue(true);
+      mockModelManager.getModelInfo.mockResolvedValue(moeModelInfo);
+      mockModelManager.getModelLayerCount.mockResolvedValue(30);
+    });
+
+    it('moves expert bytes from VRAM to RAM under cpuMoe', async () => {
+      mockLlamaServer.getConfig.mockReturnValue({
+        modelId: 'moe-26b',
+        port: 8080,
+        gpuLayers: 30,
+        cpuMoe: true,
+      });
+
+      const usage = await estimate();
+
+      // Trunk (12 - 10 = 2 GiB) x 1.2 on GPU; experts (10 GiB) x 1.2 in RAM
+      expect(usage.vram!).toBeCloseTo(2 * GiB * 1.2, -8);
+      expect(usage.ram).toBeCloseTo(10 * GiB * 1.2, -8);
+    });
+
+    it("treats overrideTensors 'exps=CPU' like cpuMoe", async () => {
+      mockLlamaServer.getConfig.mockReturnValue({
+        modelId: 'moe-26b',
+        port: 8080,
+        gpuLayers: 30,
+        overrideTensors: 'exps=CPU',
+      });
+
+      const usage = await estimate();
+
+      expect(usage.vram!).toBeCloseTo(2 * GiB * 1.2, -8);
+      expect(usage.ram).toBeCloseTo(10 * GiB * 1.2, -8);
+    });
+
+    it('splits expert bytes proportionally under nCpuMoe', async () => {
+      mockLlamaServer.getConfig.mockReturnValue({
+        modelId: 'moe-26b',
+        port: 8080,
+        gpuLayers: 30,
+        nCpuMoe: 15, // half the 30 layers → 5 GiB of experts on CPU
+      });
+
+      const usage = await estimate();
+
+      expect(usage.vram!).toBeCloseTo((12 - 5) * GiB * 1.2, -8);
+      expect(usage.ram).toBeCloseTo(5 * GiB * 1.2, -8);
+    });
+
+    it('keeps all weights on VRAM without MoE offload flags (control)', async () => {
+      mockLlamaServer.getConfig.mockReturnValue({
+        modelId: 'moe-26b',
+        port: 8080,
+        gpuLayers: 30,
+      });
+
+      const usage = await estimate();
+
+      expect(usage.vram!).toBeCloseTo(12 * GiB * 1.2, -8);
+      expect(usage.ram).toBeCloseTo(0, -8);
     });
   });
 


### PR DESCRIPTION
Closes the last v0.8.0 review finding (5b): direct exact-value tests for the orchestrator's MoE weight-split estimates — cpuMoe, `'exps=CPU'`, proportional `nCpuMoe`, and a dense control. 536/536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f