### PR TITLE
feat: structured binary-progress event for binary provisioning

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -515,6 +515,13 @@ For detailed historical information:
 
 ---
 
+## Unreleased (on main, ships with the next release)
+
+- **`'binary-progress'` event** (2026-07-03): structured companion to `'binary-log'` for binary-provisioning UIs — `BinaryProgressEvent { phase: downloading|extracting|verifying|testing, file, downloaded?, total?, percent? }`, throttled to whole-percent changes at the source, one event per phase transition, emitted by both server managers. Resolves `docs/dev/issues/ISSUE-binary-progress-event.md` (palimpsest drops its log-regex + chunk throttle). `'binary-log'` unchanged.
+- Orchestrator MoE-estimate test coverage (review finding 5b, PR #32).
+
+---
+
 ## v0.8.0: MoE-Aware Auto-Configuration (2026-07-03)
 
 **Goal/Problem:** Adaptive sizing (v0.7) treated the whole model file as GPU-resident, so MoE models with `--cpu-moe` got floor-level context and hint-less MoE got slow dense partial offload (`docs/dev/issues/ISSUE-moe-aware-auto-config.md`, filed by palimpsest-engine). Apps resorted to filename heuristics to detect MoE.

--- a/docs/dev/issues/ISSUE-binary-progress-event.md
+++ b/docs/dev/issues/ISSUE-binary-progress-event.md
@@ -1,7 +1,11 @@
 # ISSUE: Structured progress event for binary provisioning (downloads currently parseable only from log strings)
 
 Created: 2026-07-03
-Status: OPEN
+Status: RESOLVED (2026-07-03, on main — ships with the next release) — 'binary-progress'
+event implemented as proposed (+ whole-percent convenience field): throttled at the
+source, phase transitions for downloading/verifying/extracting/testing, dependency
+downloads labeled by description, forwarded by both server managers. 'binary-log'
+unchanged. See genai-electron-docs/llm-server.md#binary-progress.
 Package: genai-electron (filed from palimpsest-engine loading-UI work)
 
 ## Problem

--- a/genai-electron-docs/image-generation.md
+++ b/genai-electron-docs/image-generation.md
@@ -372,6 +372,7 @@ DiffusionServerManager extends `EventEmitter`:
 - `'started'` - Server started successfully (receives `DiffusionServerInfo`)
 - `'stopped'` - Server stopped
 - `'binary-log'` - Binary download/validation progress (receives `{ message, level }`)
+- `'binary-progress'` - Structured provisioning progress (receives `BinaryProgressEvent`: phase + file + throttled whole-percent download progress) — build progress UIs from this instead of parsing log messages
 
 **Note:** DiffusionServerManager does not emit a `'crashed'` event because it does not maintain a persistent process — stable-diffusion.cpp is spawned on-demand for each generation. Generation failures are reported via the returned promise or HTTP error responses.
 

--- a/genai-electron-docs/llm-server.md
+++ b/genai-electron-docs/llm-server.md
@@ -479,6 +479,20 @@ llamaServer.on('binary-log', (data: { message: string; level: 'info' | 'warn' | 
 });
 ```
 
+### 'binary-progress'
+
+Structured companion to `'binary-log'` for progress UIs — no log-string parsing needed. Download events are throttled to whole-percent changes at the source; each phase transition (`downloading` → `verifying` → `extracting` → `testing`) emits one event. Dependency downloads (e.g. the CUDA runtime) carry their description in `file`; the main binary uses `'binary'`.
+
+```typescript
+llamaServer.on('binary-progress', (event: BinaryProgressEvent) => {
+  if (event.phase === 'downloading') {
+    progressBar.update(event.percent!, { label: event.file });
+  } else {
+    statusLine.set(`${event.phase} ${event.file}...`);
+  }
+});
+```
+
 **Example**:
 ```typescript
 llamaServer.on('started', () => console.log('✅ Server started'));

--- a/genai-electron-docs/typescript-reference.md
+++ b/genai-electron-docs/typescript-reference.md
@@ -436,6 +436,20 @@ interface HealthCheckResponse {
 }
 ```
 
+### BinaryProgressEvent
+
+Structured provisioning progress (`'binary-progress'` event). Download events are throttled to whole-percent changes; phase transitions emit one event each.
+
+```typescript
+interface BinaryProgressEvent {
+  phase: 'downloading' | 'extracting' | 'verifying' | 'testing';
+  file: string; // 'binary' or a dependency description (e.g. 'CUDA runtime')
+  downloaded?: number; // bytes (downloading)
+  total?: number; // bytes (downloading)
+  percent?: number; // whole number (downloading)
+}
+```
+
 ### Port & Health Utilities
 
 Low-level helpers used by the server managers (also exported for advanced use).

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,7 @@ export type {
   ServerEvent,
   ServerEventData,
   BinaryLogEvent,
+  BinaryProgressEvent,
   OptimalConfigHints,
   // Image generation types (Phase 2)
   ImageSampler,

--- a/src/managers/BinaryManager.ts
+++ b/src/managers/BinaryManager.ts
@@ -11,6 +11,7 @@ import { Downloader } from '../download/Downloader.js';
 import { PATHS, getBinaryPath } from '../config/paths.js';
 import { type BinaryVariantConfig, type BinaryDependency } from '../config/defaults.js';
 import { BinaryError } from '../errors/index.js';
+import type { BinaryProgressEvent } from '../types/index.js';
 import {
   fileExists,
   ensureDirectory,
@@ -62,6 +63,12 @@ export interface BinaryManagerConfig {
   variants: readonly BinaryVariantConfig[];
   /** Optional logger function */
   log?: (message: string, level?: 'info' | 'warn' | 'error') => void;
+  /**
+   * Optional structured progress callback ('binary-progress' event source).
+   * Download progress is throttled to whole-percent changes; phase
+   * transitions (extracting/verifying/testing) emit one event each.
+   */
+  onProgress?: (event: BinaryProgressEvent) => void;
   /**
    * Optional path to a test model for real functionality testing.
    * If provided, tests will run actual inference to verify CUDA/GPU functionality.
@@ -361,14 +368,28 @@ export class BinaryManager {
 
       try {
         // Download dependency
+        let lastDepPercent = -1;
         await downloader.download({
           url: dep.url,
           destination: depArchivePath,
           onProgress: (downloaded, total) => {
             const percent = ((downloaded / total) * 100).toFixed(1);
             this.log(`Downloading ${depName}: ${percent}%`, 'info');
+            const wholePercent = Math.floor((downloaded / total) * 100);
+            if (wholePercent !== lastDepPercent) {
+              lastDepPercent = wholePercent;
+              this.progress({
+                phase: 'downloading',
+                file: depName,
+                downloaded,
+                total,
+                percent: wholePercent,
+              });
+            }
           },
         });
+
+        this.progress({ phase: 'verifying', file: depName });
 
         // Verify checksum
         const actualChecksum = await calculateChecksum(depArchivePath);
@@ -383,6 +404,7 @@ export class BinaryManager {
 
         // Extract dependency to same directory as main binary
         // This ensures DLLs are in the same directory as the executable
+        this.progress({ phase: 'extracting', file: depName });
         await extractArchive(depArchivePath, extractDir);
 
         // Cleanup dependency ZIP
@@ -423,14 +445,28 @@ export class BinaryManager {
       }
 
       // Download main binary archive
+      let lastPercent = -1;
       await downloader.download({
         url: variant.url,
         destination: archivePath,
         onProgress: (downloaded, total) => {
           const percent = ((downloaded / total) * 100).toFixed(1);
           this.log(`Downloading ${variant.type} binary: ${percent}%`, 'info');
+          const wholePercent = Math.floor((downloaded / total) * 100);
+          if (wholePercent !== lastPercent) {
+            lastPercent = wholePercent;
+            this.progress({
+              phase: 'downloading',
+              file: 'binary',
+              downloaded,
+              total,
+              percent: wholePercent,
+            });
+          }
         },
       });
+
+      this.progress({ phase: 'verifying', file: 'binary' });
 
       // Verify checksum
       const actualChecksum = await calculateChecksum(archivePath);
@@ -449,9 +485,11 @@ export class BinaryManager {
           : ['sd-cli.exe', 'sd-cli', 'sd.exe', 'sd'];
 
       // Extract main binary archive to same directory as dependencies
+      this.progress({ phase: 'extracting', file: 'binary' });
       const extractedBinaryPath = await extractBinary(archivePath, extractDir, binaryNamesToSearch);
 
       // Test if binary works (has required drivers, etc.)
+      this.progress({ phase: 'testing', file: 'binary' });
       const works = await this.testBinary(extractedBinaryPath);
 
       if (works) {
@@ -901,5 +939,13 @@ export class BinaryManager {
     if (this.config.log) {
       this.config.log(message, level);
     }
+  }
+
+  /**
+   * Emit a structured provisioning progress event (no-op without a callback)
+   * @private
+   */
+  private progress(event: BinaryProgressEvent): void {
+    this.config.onProgress?.(event);
   }
 }

--- a/src/managers/ServerManager.ts
+++ b/src/managers/ServerManager.ts
@@ -34,6 +34,7 @@ import { getPlatformKey } from '../utils/platform-utils.js';
  * - 'crashed': When server crashes unexpectedly
  * - 'restarted': When server restarts after a crash
  * - 'binary-log': When binary download/testing emits log messages (message: string, level: 'info' | 'warn' | 'error')
+ * - 'binary-progress': Structured provisioning progress (BinaryProgressEvent; download events throttled to whole percents)
  *
  * @example
  * ```typescript
@@ -513,6 +514,10 @@ export abstract class ServerManager extends EventEmitter {
         this.logManager?.write(message, level).catch(() => void 0);
         // Emit event for UI
         this.emit('binary-log', { message, level });
+      },
+      onProgress: (event) => {
+        // Structured companion to 'binary-log' for progress UIs
+        this.emit('binary-progress', event);
       },
     });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export type {
   ServerEvent,
   ServerEventData,
   BinaryLogEvent,
+  BinaryProgressEvent,
   OptimalConfigHints,
 } from './servers.js';
 

--- a/src/types/servers.ts
+++ b/src/types/servers.ts
@@ -261,7 +261,8 @@ export type ServerEvent =
   | 'restarted'
   | 'health-check-ok'
   | 'health-check-failed'
-  | 'binary-log';
+  | 'binary-log'
+  | 'binary-progress';
 
 /**
  * Server event data
@@ -290,4 +291,28 @@ export interface BinaryLogEvent {
 
   /** Log level */
   level: 'info' | 'warn' | 'error';
+}
+
+/**
+ * Structured progress for binary provisioning ('binary-progress' event)
+ *
+ * Machine-readable companion to 'binary-log': download progress is throttled
+ * to whole-percent changes at the source, and each phase transition emits one
+ * event. Build progress UIs from this instead of parsing log strings.
+ */
+export interface BinaryProgressEvent {
+  /** Provisioning phase */
+  phase: 'downloading' | 'extracting' | 'verifying' | 'testing';
+
+  /** What is being provisioned: 'binary' or a dependency description */
+  file: string;
+
+  /** Bytes downloaded so far (phase === 'downloading') */
+  downloaded?: number;
+
+  /** Total bytes, when known (phase === 'downloading') */
+  total?: number;
+
+  /** Whole-number download percentage convenience (phase === 'downloading') */
+  percent?: number;
 }

--- a/tests/unit/BinaryManager.test.ts
+++ b/tests/unit/BinaryManager.test.ts
@@ -483,6 +483,101 @@ describe('BinaryManager', () => {
     });
   });
 
+  describe('binary-progress events', () => {
+    it('throttles download progress to whole-percent changes and emits phase transitions', async () => {
+      const progressEvents: Array<Record<string, unknown>> = [];
+      const manager = new BinaryManager({
+        type: 'llama',
+        binaryName: 'llama-server',
+        platformKey: 'win32-x64',
+        variants: [cpuVariant],
+        log: mockLogger,
+        onProgress: (e) => progressEvents.push(e as unknown as Record<string, unknown>),
+      });
+
+      // Simulate chunky download: multiple callbacks inside the same percent
+      mockDownload.mockImplementation(async (opts: any) => {
+        const total = 1000;
+        for (const downloaded of [1, 2, 3, 251, 252, 503, 1000]) {
+          opts.onProgress?.(downloaded, total);
+        }
+      });
+      mockDetectGPU.mockResolvedValue({ available: false });
+
+      await manager.ensureBinary();
+
+      const downloading = progressEvents.filter((e) => e.phase === 'downloading');
+      // 1,2,3 -> 0%; 251,252 -> 25%; 503 -> 50%; 1000 -> 100% => 4 events
+      expect(downloading.map((e) => e.percent)).toEqual([0, 25, 50, 100]);
+      expect(downloading[0]).toMatchObject({ file: 'binary', downloaded: 1, total: 1000 });
+
+      const phases = progressEvents.map((e) => `${e.phase}:${e.file}`);
+      expect(phases).toContain('verifying:binary');
+      expect(phases).toContain('extracting:binary');
+      expect(phases).toContain('testing:binary');
+      // Order: all downloading events precede verifying -> extracting -> testing
+      expect(phases.indexOf('verifying:binary')).toBeGreaterThan(
+        phases.lastIndexOf('downloading:binary')
+      );
+      expect(phases.indexOf('extracting:binary')).toBeGreaterThan(
+        phases.indexOf('verifying:binary')
+      );
+      expect(phases.indexOf('testing:binary')).toBeGreaterThan(phases.indexOf('extracting:binary'));
+    });
+
+    it('labels dependency downloads with the dependency description', async () => {
+      const progressEvents: Array<Record<string, unknown>> = [];
+      const depVariant: BinaryVariantConfig = {
+        type: 'cuda',
+        url: 'https://example.com/llama-cuda.zip',
+        checksum: 'abc123cuda',
+        dependencies: [
+          {
+            url: 'https://example.com/cudart.zip',
+            checksum: 'depchecksum',
+            description: 'CUDA runtime',
+          },
+        ],
+      };
+      mockCalculateChecksum.mockImplementation(async (path: string) => {
+        if (path.includes('.dep0')) return 'depchecksum';
+        return 'abc123cuda';
+      });
+      const manager = new BinaryManager({
+        type: 'llama',
+        binaryName: 'llama-server',
+        platformKey: 'win32-x64',
+        variants: [depVariant],
+        log: mockLogger,
+        onProgress: (e) => progressEvents.push(e as unknown as Record<string, unknown>),
+      });
+
+      mockDownload.mockImplementation(async (opts: any) => {
+        opts.onProgress?.(500, 1000);
+        opts.onProgress?.(1000, 1000);
+      });
+
+      await manager.ensureBinary();
+
+      const depEvents = progressEvents.filter((e) => e.file === 'CUDA runtime');
+      expect(depEvents.map((e) => `${e.phase}:${e.percent ?? ''}`)).toEqual([
+        'downloading:50',
+        'downloading:100',
+        'verifying:',
+        'extracting:',
+      ]);
+    });
+
+    it('emits nothing without an onProgress callback (no throw)', async () => {
+      mockDownload.mockImplementation(async (opts: any) => {
+        opts.onProgress?.(1000, 1000);
+      });
+      mockDetectGPU.mockResolvedValue({ available: false });
+
+      await expect(binaryManager.ensureBinary()).resolves.toBeDefined();
+    });
+  });
+
   describe('downloadAndTestVariant()', () => {
     it('should cleanup on download failure', async () => {
       // Make download fail for ALL variants


### PR DESCRIPTION
Resolves `ISSUE-binary-progress-event.md`: structured `'binary-progress'` event (phase + file + throttled whole-percent bytes) alongside the unchanged `'binary-log'`, so progress UIs stop regexing log strings. Emitted by both server managers; dependency downloads labeled by description. 539/539 tests. **No version bump — ships with the next batched release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f