### PR TITLE
release: v0.9.0 — structured binary-provisioning progress

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,13 +1,13 @@
 # genai-electron Implementation Progress
 
-> **Current Status**: v0.8.0 — MoE-aware auto-configuration (2026-07-03)
+> **Current Status**: v0.9.0 — structured binary-provisioning progress event (2026-07-03)
 
 ---
 
 ## Current Build Status
 
 - **Build:** ✅ 0 TypeScript errors
-- **Tests:** ✅ 536/536 passing (21 suites)
+- **Tests:** ✅ 539/539 passing (21 suites)
 - **Branch:** `main`
 - **Last Updated:** 2026-07-03 (v0.6.1: security patch — npm audit clean, tar minimum ^7.5.19)
 
@@ -515,10 +515,12 @@ For detailed historical information:
 
 ---
 
-## Unreleased (on main, ships with the next release)
+## v0.9.0: Structured Binary-Provisioning Progress (2026-07-03)
 
-- **`'binary-progress'` event** (2026-07-03): structured companion to `'binary-log'` for binary-provisioning UIs — `BinaryProgressEvent { phase: downloading|extracting|verifying|testing, file, downloaded?, total?, percent? }`, throttled to whole-percent changes at the source, one event per phase transition, emitted by both server managers. Resolves `docs/dev/issues/ISSUE-binary-progress-event.md` (palimpsest drops its log-regex + chunk throttle). `'binary-log'` unchanged.
-- Orchestrator MoE-estimate test coverage (review finding 5b, PR #32).
+- **`'binary-progress'` event**: structured companion to `'binary-log'` for binary-provisioning UIs — `BinaryProgressEvent { phase: downloading|extracting|verifying|testing, file, downloaded?, total?, percent? }`, throttled to whole-percent changes at the source, one event per phase transition, emitted by both server managers. Resolves `docs/dev/issues/ISSUE-binary-progress-event.md` (palimpsest drops its log-regex + chunk throttle). `'binary-log'` unchanged.
+- Orchestrator MoE-estimate test coverage (v0.8.0 review finding 5b, PR #32).
+
+**Build Status:** ✅ 0 TypeScript errors / 539/539 tests passing (21 suites)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai-electron
 
-> **Version**: 0.8.0 | **Status**: Production Ready - LLM & Image Generation, hardened server lifecycle
+> **Version**: 0.9.0 | **Status**: Production Ready - LLM & Image Generation, hardened server lifecycle
 
 Electron-specific library for managing local AI model servers (llama.cpp, stable-diffusion.cpp). Handles platform-specific operations to run AI models locally. Complements [genai-lite](https://github.com/lacerbi/genai-lite) for API abstraction.
 

--- a/genai-electron-docs/index.md
+++ b/genai-electron-docs/index.md
@@ -1,6 +1,6 @@
 # genai-electron Documentation
 
-> **Version**: 0.8.0 (MoE-Aware Auto-Configuration)
+> **Version**: 0.9.0 (Structured Binary-Provisioning Progress)
 > **Status**: Production Ready - LLM & Image Generation
 
 Complete documentation for genai-electron - An Electron-specific library for managing local AI model servers and resources.
@@ -26,6 +26,7 @@ Complete documentation for genai-electron - An Electron-specific library for man
 - **[Troubleshooting](troubleshooting.md)** - Common issues, error codes, FAQ
 
 ### Migration
+- **[Migrating from v0.8.x to v0.9.0](migration-0-8-to-0-9.md)** - Structured `'binary-progress'` event for provisioning UIs
 - **[Migrating from v0.7.x to v0.8.0](migration-0-7-to-0-8.md)** - MoE-aware sizing: automatic `cpuMoe` for too-big MoE models, expert-weights measurement
 - **[Migrating from v0.6.x to v0.7.0](migration-0-6-to-0-7.md)** - Adaptive context sizing, automatic q8_0 KV quantization, full-offload preference
 - **[Migrating from v0.5.x to v0.6.0](migration-0-5-to-0-6.md)** - Optional/`'auto'` ports, always-on `--jinja`, multi-shard models, generation cancellation

--- a/genai-electron-docs/migration-0-8-to-0-9.md
+++ b/genai-electron-docs/migration-0-8-to-0-9.md
@@ -1,0 +1,41 @@
+# Migrating from v0.8.x to v0.9.0
+
+v0.9.0 is a small additive release: a **structured progress event for binary provisioning**, so loading UIs no longer parse `'binary-log'` message strings.
+
+## Compatibility
+
+Fully backwards-compatible. `'binary-log'` is unchanged; if you parse its messages today, nothing breaks — but switch to `'binary-progress'` so the log wording stops being an implicit API contract.
+
+## What's New
+
+### `'binary-progress'` event
+
+Emitted by both `llamaServer` and `diffusionServer` during first-run binary provisioning:
+
+```typescript
+llamaServer.on('binary-progress', (event: BinaryProgressEvent) => {
+  if (event.phase === 'downloading') {
+    progressBar.update(event.percent!, { label: event.file });
+  } else {
+    statusLine.set(`${event.phase} ${event.file}...`);
+  }
+});
+```
+
+```typescript
+interface BinaryProgressEvent {
+  phase: 'downloading' | 'extracting' | 'verifying' | 'testing';
+  file: string; // 'binary' or a dependency description (e.g. 'CUDA runtime')
+  downloaded?: number; // bytes (downloading)
+  total?: number; // bytes (downloading)
+  percent?: number; // whole number (downloading)
+}
+```
+
+- Download events are **throttled to whole-percent changes at the source** — no consumer-side throttling needed (`'binary-log'` still fires per chunk).
+- Each phase transition emits one event; dependency downloads carry their description in `file`.
+- `BinaryProgressEvent` is exported from the package root and listed in the [TypeScript Reference](typescript-reference.md#binaryprogressevent).
+
+## See Also
+
+- [LLM Server — events](llm-server.md) · [Migrating 0.7 → 0.8](migration-0-7-to-0-8.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-electron",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-electron",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/gguf": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-electron",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Electron-specific library for managing local AI model servers and resources",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * to run AI models locally on desktop systems.
  *
  * @module genai-electron
- * @version 0.8.0
+ * @version 0.9.0
  * @license MIT
  *
  * @example


### PR DESCRIPTION
Release housekeeping for v0.9.0: version strings, compact migration guide, PROGRESS entry. Feature content already on main (#32, #33). 539/539 tests; pack dry-run clean (106.3 kB, 163 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f