### PR TITLE
docs: post-v0.9.0 handoff — refresh follow-ups, record release workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,8 @@ This is documented in the electron-control-panel example for reference.
 
 **Note**: CI will fail if any of these checks fail. Run them locally before pushing.
 
+**Release workflow** (agreed 2026-07-03): fixes/features accumulate **unreleased** — on a batch branch, or on main under a PROGRESS "Unreleased" section — with no version bump, tag, npm publish, or (when batching on a branch) even PRs, until the user explicitly says to release. Then: one release PR (version strings, migration guide, PROGRESS entry) → merge → tag → GitHub release → the user runs `npm publish` (guarded by `prepublishOnly`). New ISSUE files appearing at the repo root are proposals to READ and confirm with the user before acting on.
+
 **When Adding New Features**:
 1. Check if it's planned in DESIGN.md (phases 2-5)
 2. Update PROGRESS.md with concise summary of changes

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -490,11 +490,13 @@ For detailed historical information:
 
 **Released:** v0.6.1 published to npm (2026-07-03; 0.6.0 was tagged but never published — the audit patch superseded it). GitHub Release on tag `v0.6.1`.
 
-**Follow-ups (agreed, not yet started):**
+**Follow-ups (agreed, not yet started; updated 2026-07-03 post-v0.9.0):**
+- **palimpsest-engine integration** (downstream, next natural step) — consume v0.8/0.9: drop the MoE filename regex (`/-a\d+b/i`) + manual `cpuMoe`/`gpuLayers: 999`/pinned-context path (v0.8 auto-config covers it), and the `binary-log` percent regex + throttle (subscribe to `'binary-progress'`, v0.9).
 - **stable-diffusion.cpp bump** — pin `master-504-636d3cb` is ~242 releases behind (`master-746-2574f59` as of 2026-07-02). Needs its own plan: sd-cli flag surface may have changed; re-validate diffusion per platform. (Plan Open Question 1, resolved as separate follow-up.)
 - **Example-app toolchain chore** — Electron Forge devDependency chain carries npm-audit highs fixable only via major bumps (electron 35→43 + Forge majors). Dev-only, outside the published package and CI's root-only audit gate.
+- **Example app: forward `'binary-progress'` over IPC** — the control panel still forwards only `'binary-log'`; wire the structured event through preload/renderer for a real progress bar (small; pairs with the toolchain chore).
 - **ROCm/HIP binary variants** — upstream now ships `win-hip-radeon` + `ubuntu-rocm` prebuilts; blocked on Windows AMD GPU detection (DESIGN Phase 4).
-- **genai-lite**: `GenaiElectronImageAdapter` should treat `'cancelled'` as terminal — filed and committed in that repo (`docs/ISSUE-cancelled-generation-status.md`).
+- ~~genai-lite `'cancelled'` terminal status~~ — RESOLVED in genai-lite v0.9.2.
 
 ---
 


### PR DESCRIPTION
Handoff bookkeeping: follow-ups list refreshed (palimpsest integration, example-app binary-progress IPC; genai-lite item resolved), release-workflow agreement recorded in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f