### PR TITLE
release: v0.10.0 — stable-diffusion.cpp master-746-2574f59, CUDA offload guard retired

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # genai-electron Implementation Progress
 
-> **Current Status**: v0.9.0 released; v0.10.0 batch (sd.cpp bump + CUDA offload guard retirement) ready for release (2026-07-04)
+> **Current Status**: v0.10.0 — stable-diffusion.cpp master-746-2574f59 + CUDA offload guard retirement (2026-07-04)
 
 ---
 
@@ -8,8 +8,8 @@
 
 - **Build:** ✅ 0 TypeScript errors
 - **Tests:** ✅ 543/543 passing (21 suites)
-- **Branch:** `feat/sd-cpp-bump`
-- **Last Updated:** 2026-07-04 (v0.10.0 batch: stable-diffusion.cpp master-746-2574f59)
+- **Branch:** `main`
+- **Last Updated:** 2026-07-04 (v0.10.0 release)
 
 ---
 
@@ -524,7 +524,7 @@ For detailed historical information:
 
 ---
 
-## v0.10.0 (Unreleased): stable-diffusion.cpp master-746-2574f59 + CUDA Offload Guard Retirement (2026-07-04)
+## v0.10.0: stable-diffusion.cpp master-746-2574f59 + CUDA Offload Guard Retirement (2026-07-04)
 
 **Goal/Problem:** The diffusion binary pin (`master-504-636d3cb`, 2026-02-10) was 242 releases behind upstream. Bump to the latest release, re-validate the whole sd-cli surface (flags, log formats, asset scheme), and retire workarounds that no longer apply. Plan: `docs/dev/plans/PLAN-sd-cpp-bump.md`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai-electron
 
-> **Version**: 0.9.0 | **Status**: Production Ready - LLM & Image Generation, hardened server lifecycle
+> **Version**: 0.10.0 | **Status**: Production Ready - LLM & Image Generation, refreshed stable-diffusion.cpp runtime
 
 Electron-specific library for managing local AI model servers (llama.cpp, stable-diffusion.cpp). Handles platform-specific operations to run AI models locally. Complements [genai-lite](https://github.com/lacerbi/genai-lite) for API abstraction.
 

--- a/docs/dev/plans/PLAN-sd-cpp-bump.md
+++ b/docs/dev/plans/PLAN-sd-cpp-bump.md
@@ -134,9 +134,9 @@ Bump the pinned stable-diffusion.cpp binaries by 242 releases (2026-02-10 → 20
 
 **Steps**:
 1. [x] PROGRESS.md: new v0.10.0 section — bump details (242 releases, backward-compatible surface, win-cpu consolidation, Linux Vulkan variant added), guard outcome with smoke evidence (box specs, models, per-flag matrix), riders; **fold-in line for `36952da`** (genai-lite 0.11 pairing notes; example pins genai-lite ^0.11.0 — already on main, previously unrecorded); strike the sd-bump follow-up (~line 501); add the cudart re-download-skip follow-up; refresh the status block (test counts, date)
-2. [ ] Update README status line (version/status) as part of the release PR
+2. [x] Update README status line (version/status) as part of the release PR
 3. [x] (PR #36: https://github.com/lacerbi/genai-electron/pull/36) Push branch, open PR (single batch PR per release workflow), request user review
-4. [ ] On user go-ahead: release PR mechanics — `package.json` version 0.10.0, migration note if the guard was retired (behavior change), merge → tag `v0.10.0` → GitHub release; **user runs `npm publish`** (guarded by `prepublishOnly`)
+4. [~] (go-ahead received 2026-07-04; release PR in flight) On user go-ahead: release PR mechanics — `package.json` version 0.10.0, migration note if the guard was retired (behavior change), merge → tag `v0.10.0` → GitHub release; **user runs `npm publish`** (guarded by `prepublishOnly`)
 
 **Verification**:
 - [x] CI green on the PR (all 6 checks: Code Quality, Package Validation, Security Audit, Node 22 tests on macos/ubuntu/windows)

--- a/genai-electron-docs/index.md
+++ b/genai-electron-docs/index.md
@@ -1,6 +1,6 @@
 # genai-electron Documentation
 
-> **Version**: 0.9.0 (Structured Binary-Provisioning Progress)
+> **Version**: 0.10.0 (stable-diffusion.cpp master-746 + CUDA offload auto-detection)
 > **Status**: Production Ready - LLM & Image Generation
 
 Complete documentation for genai-electron - An Electron-specific library for managing local AI model servers and resources.
@@ -26,6 +26,7 @@ Complete documentation for genai-electron - An Electron-specific library for man
 - **[Troubleshooting](troubleshooting.md)** - Common issues, error codes, FAQ
 
 ### Migration
+- **[Migrating from v0.9.x to v0.10.0](migration-0-9-to-0-10.md)** - stable-diffusion.cpp master-746 bump; CPU-offload flags now auto-detected on CUDA too
 - **[Migrating from v0.8.x to v0.9.0](migration-0-8-to-0-9.md)** - Structured `'binary-progress'` event for provisioning UIs
 - **[Migrating from v0.7.x to v0.8.0](migration-0-7-to-0-8.md)** - MoE-aware sizing: automatic `cpuMoe` for too-big MoE models, expert-weights measurement
 - **[Migrating from v0.6.x to v0.7.0](migration-0-6-to-0-7.md)** - Adaptive context sizing, automatic q8_0 KV quantization, full-offload preference

--- a/genai-electron-docs/migration-0-9-to-0-10.md
+++ b/genai-electron-docs/migration-0-9-to-0-10.md
@@ -1,0 +1,39 @@
+# Migrating from v0.9.x to v0.10.0
+
+v0.10.0 refreshes the **stable-diffusion.cpp runtime**: the pinned binaries jump 242 releases (`master-504-636d3cb` → `master-746-2574f59`), with one behavior change around CUDA CPU-offloading.
+
+## Compatibility
+
+API-compatible — no signatures changed. Two behavioral notes:
+
+### CPU-offload flags now apply on CUDA (behavior change)
+
+Previously, auto-detection never enabled `clipOnCpu` / `vaeOnCpu` / `offloadToCpu` on CUDA installs — a workaround for a silent crash (`0xC0000005`) in older sd.cpp CUDA builds. That crash is fixed upstream (re-verified live on `master-746-2574f59`, each flag alone and all three combined), so auto-detection is now identical on all backends.
+
+Practical effect: low-VRAM CUDA setups may now auto-enable these flags — generations get slower but VRAM-safer (e.g. a 5 GB Flux 2 Klein on an 8 GB GPU now auto-enables `--clip-on-cpu`). Restore the old behavior with explicit `false`:
+
+```typescript
+await diffusionServer.start({
+  modelId: 'flux-2-klein',
+  clipOnCpu: false,
+  vaeOnCpu: false,
+  offloadToCpu: false,
+});
+```
+
+**Upstream caveat:** SD3.5-Large conditioning is broken with `--clip-on-cpu` on *any* backend (leejet/stable-diffusion.cpp#1578) — pass `clipOnCpu: false` for that model family.
+
+### Binary re-download on upgrade
+
+The first `diffusionServer.start()` after upgrading re-provisions the binaries for the new pin (the cache is version-tagged): ~360 MB CUDA + 563 MB CUDA runtime on Windows NVIDIA, ~38 MB Vulkan, ~24 MB CPU.
+
+## What's New
+
+- **Windows CPU build**: runtime CPU dispatch — one zip works on every x64 CPU (replaces the AVX2-only build)
+- **Linux Vulkan variant** ahead of the CPU fallback — Linux GPU acceleration out of the box
+- **New samplers**: `er_sde`, `euler_cfg_pp`, `euler_a_cfg_pp`
+- Loading-stage progress reporting adapted to the new sd.cpp log format (byte-rate progress bars)
+
+## See Also
+
+- [Image Generation](image-generation.md) · [Troubleshooting — CUDA + CPU offloading](troubleshooting.md) · [Migrating 0.8 → 0.9](migration-0-8-to-0-9.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-electron",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-electron",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/gguf": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-electron",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Electron-specific library for managing local AI model servers and resources",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * to run AI models locally on desktop systems.
  *
  * @module genai-electron
- * @version 0.9.0
+ * @version 0.10.0
  * @license MIT
  *
  * @example


### PR DESCRIPTION
Version bump + release docs for the v0.10.0 batch (merged in #36).

- `package.json`/`package-lock.json`/`src/index.ts`: 0.9.0 → 0.10.0
- README + docs-index version/status lines
- New `genai-electron-docs/migration-0-9-to-0-10.md` (behavior change: CPU-offload flags now auto-detected on CUDA; binary re-download on upgrade; new samplers)
- PROGRESS v0.10.0 entry finalized

After merge: tag `v0.10.0` + GitHub release; `npm publish` runs maintainer-side (guarded by `prepublishOnly`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f