### PR TITLE
feat: diffusion offload calibration API (diffusionServer.calibrate())

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ src/
 - **Multi-Component**: `DIFFUSION_COMPONENT_FLAGS`, `DIFFUSION_COMPONENT_ORDER`, `getModelDirectory()` - Multi-file diffusion model support
 - **Port Utilities**: `findFreePort()`, `isPortBindable()` - Free-port selection and bind testing (also `port: 'auto'` on server configs)
 - **Cancellation**: `DiffusionServerManager.cancelImageGeneration()` / `getActiveGenerationId()` - Cancel in-flight async image generation (also `DELETE /v1/images/generations/:id`)
+- **Offload Calibration**: `DiffusionServerManager.calibrate()` / `isCalibrating()`, `DIFFUSION_CALIBRATION_DEFAULTS`, `'calibration-progress'` event - Benchmark CPU-offload flag combos per machine (types: `DiffusionOffloadCombo`, `CalibrationSize`, `CalibrationRun`, `DiffusionCalibration{Config,Progress,Report}`)
 - **Types**: `DiffusionComponentRole`, `DiffusionComponentInfo`, `DiffusionModelComponents`, `DiffusionComponentDownload`, `ShardInfo`, `KVCacheType`, `FlashAttentionSetting`, `LogRotationOptions`
 - **Complete list**: See `src/index.ts` for all exported utilities, types, and classes
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -28,9 +28,9 @@
 - SD3.5-Large guard: forced `clipOnCpu: true` combos auto-skipped → `report.skippedCombos` (upstream leejet/stable-diffusion.cpp#1578)
 - New exports: `DiffusionOffloadCombo`, `CalibrationSize`, `DiffusionCalibrationConfig/Progress/Report`, `CalibrationRun`, `DIFFUSION_CALIBRATION_DEFAULTS`
 
-**Files Modified:** `src/types/{images,index}.ts`, `src/index.ts`, `src/config/defaults.ts`, `src/managers/{DiffusionServerManager,ResourceOrchestrator}.ts`, `tests/unit/diffusion-calibration.test.ts` (new, 20 cases), docs (`image-generation` "Offload Calibration" section, `typescript-reference`, `resource-orchestration`), example app (calibration UI)
+**Files Modified:** `src/types/{images,index}.ts`, `src/index.ts`, `src/config/defaults.ts`, `src/managers/{DiffusionServerManager,ResourceOrchestrator}.ts`, `tests/unit/diffusion-calibration.test.ts` (new, 23 cases), docs (`image-generation` "Offload Calibration" section, `typescript-reference`, `resource-orchestration`, index/troubleshooting cross-refs), example app (calibration UI)
 
-**Build Status:** ✅ 0 TypeScript errors / 563/563 tests passing (22 suites)
+**Build Status:** ✅ 0 TypeScript errors / 566/566 tests passing (22 suites)
 
 **Live smoke (2026-07-04, RTX 4060 Laptop 8 GB, flux-2-klein-q40 768²/4-step):** full default sweep passed — recommended `clip-gpu` at 17.1 s median vs auto's 33.5 s (~2×); `vaeOnCpu` decode trap confirmed (97.3 s, decode 66 s); 5% tie-break exercised live (`all-resident` 16.9 s / `clip-gpu` 17.1 s / `clip-gpu+offload` 17.4 s → fewest forced flags won); progress monotonic, phases in order, callback/event parity (2303 events); post-sweep normal `start()` + generation with recommended flags OK, server left stopped. Details: `docs/dev/plans/PLAN-diffusion-calibration.md` Phase 6.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -32,6 +32,8 @@
 
 **Build Status:** ✅ 0 TypeScript errors / 563/563 tests passing (22 suites)
 
+**Live smoke (2026-07-04, RTX 4060 Laptop 8 GB, flux-2-klein-q40 768²/4-step):** full default sweep passed — recommended `clip-gpu` at 17.1 s median vs auto's 33.5 s (~2×); `vaeOnCpu` decode trap confirmed (97.3 s, decode 66 s); 5% tie-break exercised live (`all-resident` 16.9 s / `clip-gpu` 17.1 s / `clip-gpu+offload` 17.4 s → fewest forced flags won); progress monotonic, phases in order, callback/event parity (2303 events); post-sweep normal `start()` + generation with recommended flags OK, server left stopped. Details: `docs/dev/plans/PLAN-diffusion-calibration.md` Phase 6.
+
 ---
 
 ## Completed Phases

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,15 +1,36 @@
 # genai-electron Implementation Progress
 
-> **Current Status**: v0.10.0 — stable-diffusion.cpp master-746-2574f59 + CUDA offload guard retirement (2026-07-04)
+> **Current Status**: v0.10.0 released — diffusion offload calibration accumulating unreleased (2026-07-04)
 
 ---
 
 ## Current Build Status
 
 - **Build:** ✅ 0 TypeScript errors
-- **Tests:** ✅ 543/543 passing (21 suites)
-- **Branch:** `main`
-- **Last Updated:** 2026-07-04 (v0.10.0 release)
+- **Tests:** ✅ 563/563 passing (22 suites)
+- **Branch:** `feat/diffusion-calibration` (unreleased batch)
+- **Last Updated:** 2026-07-04 (offload calibration)
+
+---
+
+## Unreleased
+
+### Diffusion Offload Calibration — `diffusionServer.calibrate()` (2026-07-04)
+
+**Goal/Problem:** The static VRAM heuristic cannot pick the fastest CPU-offload flag combo — the optimum is machine-dependent and the flags interact (measured on an 8 GB Win11 laptop with Flux 2 Klein: auto ~18 s vs `clipOnCpu:false`+`offloadToCpu:true` ~10–12 s; `vaeOnCpu` ~3× slower; Windows thrashes where Linux hard-OOMs). Only a live sweep on the target machine can decide. Proposal: `docs/dev/issues/ISSUE-diffusion-offload-calibration.md`; plan: `docs/dev/plans/PLAN-diffusion-calibration.md`.
+
+**Core Features:**
+- `calibrate(config)` on DiffusionServerManager: benchmarks offload combos × sizes with real generations (fixed seed/steps/prompt/sampler → identical work per combo), 1 discarded warmup per combo + median-of-samples timing, per-stage split (`stageMs`: load/diffusion/decode), OOM-vs-error classification from stderr/exit code, per-size `recommended` (5% tie tolerance prefers fewer forced flags)
+- **No server restarts:** per-generation flag overrides threaded through `computeDiffusionOptimizations` (flags resolve per spawn); server must be stopped, is left stopped; `start()` guarded during sweeps; `isCalibrating()`
+- Sweep-level LLM offload/restore via the internal orchestrator (`waitForReload()` → `offloadLLM()` once, `reloadLLM()` in finally; both promoted to public API)
+- Progress for UIs: guarded `onProgress` callback + `'calibration-progress'` event (same payload; smooth monotonic `overallPercent` with within-generation folding) — IPC-forwardable like `'binary-progress'`
+- Abort via `AbortSignal` → `ServerError` with `details.code = 'CALIBRATION_ABORTED'` + partial runs in `details.runs`
+- SD3.5-Large guard: forced `clipOnCpu: true` combos auto-skipped → `report.skippedCombos` (upstream leejet/stable-diffusion.cpp#1578)
+- New exports: `DiffusionOffloadCombo`, `CalibrationSize`, `DiffusionCalibrationConfig/Progress/Report`, `CalibrationRun`, `DIFFUSION_CALIBRATION_DEFAULTS`
+
+**Files Modified:** `src/types/{images,index}.ts`, `src/index.ts`, `src/config/defaults.ts`, `src/managers/{DiffusionServerManager,ResourceOrchestrator}.ts`, `tests/unit/diffusion-calibration.test.ts` (new, 20 cases), docs (`image-generation` "Offload Calibration" section, `typescript-reference`, `resource-orchestration`), example app (calibration UI)
+
+**Build Status:** ✅ 0 TypeScript errors / 563/563 tests passing (22 suites)
 
 ---
 

--- a/docs/dev/issues/ISSUE-diffusion-offload-calibration.md
+++ b/docs/dev/issues/ISSUE-diffusion-offload-calibration.md
@@ -1,0 +1,309 @@
+# Diffusion offload calibration (per-machine sweep API)
+
+**Type:** feature request
+**Area:** `DiffusionServerManager` / image generation
+**Status:** RESOLVED (2026-07-04) — see resolution note below
+**Version target:** genai-electron ≥ 0.10.x
+
+> **Status: RESOLVED** (2026-07-04, on `feat/diffusion-calibration` — unreleased batch).
+> Implemented as `DiffusionServerManager.calibrate()` per
+> `docs/dev/plans/PLAN-diffusion-calibration.md`, with these deviations from the
+> proposal below:
+>
+> - **No restart per combo** — offload flags resolve per generation inside
+>   `executeImageGeneration()`, so the sweep threads per-combo overrides into each
+>   spawn directly. No HTTP server or port involvement at all; the "sweep restarts
+>   per combo" acceptance test became "per-run flag resolution".
+> - **Abort throws** (the proposed "existing stop path" would silently no-op while
+>   status is `'stopped'`, which it is throughout calibration): a `ServerError` with
+>   `details.code = 'CALIBRATION_ABORTED'` and partial runs in `details.runs`
+>   (top-level `error.code` stays the generic `'SERVER_ERROR'`).
+> - Tie-break made deterministic: any OK combo within **5%** of the fastest that
+>   forces fewer flags wins (robustness preference).
+> - Progress phases reworked (`'starting'` → `'preparing'`, added `'restoring-llm'`)
+>   and the payload enriched (combo/size/sample context + `generationPercent` for
+>   smooth bars); also emitted as a `'calibration-progress'` event for IPC forwarding.
+> - Report gains `skippedCombos` + a methodology echo (`steps`/`sampler`/`samples`);
+>   default combos ship labeled; `isCalibrating()` added; the optional standalone
+>   `calibrateDiffusion()` wrapper was not implemented (the manager method suffices).
+> - LLM handling: sweep-level offload/restore via the internal orchestrator
+>   (`waitForReload()` → `offloadLLM()` once at sweep start; `reloadLLM()` in the
+>   finally; both promoted to public `ResourceOrchestrator` API).
+>
+> Docs: `genai-electron-docs/image-generation.md` → "Offload Calibration".
+
+## Summary
+
+Add a **calibration** API that benchmarks the CPU-offload flag combinations
+(`clipOnCpu` / `vaeOnCpu` / `offloadToCpu` / `diffusionFlashAttention`) on the
+**actual machine** for a given model and image size(s), and returns the fastest
+working configuration. The caller then applies/persists the result.
+
+genai-electron already picks these flags via a static VRAM heuristic
+(`DiffusionServerManager.computeDiffusionOptimizations()`). Real-world testing
+shows the optimum is **not** a simple function of VRAM — it depends on the whole
+system (driver behaviour, PCIe bandwidth, CPU speed, RAM bandwidth, OS), and the
+flags **interact** in non-obvious ways. The only reliable way to pick the best
+config is to **measure it on the target machine**. That measurement machinery is
+completely general and belongs here, not in each consumer app.
+
+## Motivation (empirical)
+
+Measured on an **8 GB laptop GPU, Windows 11**, model **Flux 2 Klein (Q4_0)**
+(multi-component: Flux DiT + Qwen3-4B text encoder + VAE), via a consumer app's
+"generate one image and show the time" panel:
+
+| Config | Time / image |
+|---|---|
+| Auto (heuristic picks `clipOnCpu=true`) | ~18 s |
+| `clipOnCpu=false` (rest auto) | ~13 s |
+| `vaeOnCpu=true` | **~3× slower** |
+| `clipOnCpu=false` + `offloadToCpu=true` | **~10–12 s (best)** |
+| `offloadToCpu=true` alone | ~no change vs auto |
+
+Why these are not obvious, and why a static heuristic can't capture them:
+
+- **`vaeOnCpu` is almost always a trap.** CPU decode of the (large) Flux latent
+  dominates the run — the current auto only enables it below 2 GB headroom, which
+  is right, but a naive "save VRAM" default would be badly wrong.
+- **`clipOnCpu=false` is a big win *if it fits*** — Flux's "CLIP" is a 4B LLM, so
+  moving it to the GPU saves the multi-second CPU encode. But forcing it onto an
+  8 GB GPU oversubscribes VRAM.
+- **`offloadToCpu` looks inert alone but is decisive under pressure.** With CLIP
+  on CPU (low GPU pressure) it has nothing to stream → ~no effect. But
+  `clip=false` **oversubscribes** VRAM; on Windows the driver then silently spills
+  to shared system RAM *ad-hoc* (thrash). `offloadToCpu=true` replaces that with
+  sd.cpp's **orderly** weight streaming → faster than driver thrash. Hence the
+  best combo (`clip=false` + `offload=true`) beats either alone, and `offload`
+  alone appears to do nothing. **This proves `offloadToCpu` works** — it's just
+  conditional on the VRAM pressure that `clip=false` creates.
+
+Critically, **this is platform-dependent**: Windows/WDDM silently oversubscribes
+VRAM (slow but runs); Linux/CUDA typically **hard-OOMs** instead. So the same
+`clip=false` combo that is merely "slower until you add offload" on Windows may
+**fail outright** on Linux — a static heuristic cannot know which. Only a live
+sweep that actually runs each combo and observes success + wall-clock can decide.
+
+## Why this belongs in genai-electron
+
+The sweep needs exactly the things this library owns: the flag config
+(`DiffusionServerConfig`), the server start/stop lifecycle, per-generation
+execution (`generateImage`), hardware detection (`SystemInfo.getGPUInfo()`), and
+per-stage timing. A consumer app can only script it clumsily from outside
+(repeated start/stop/generate) and can't classify OOM vs slow reliably. The
+**only** consumer-specific input is *which image dimensions to benchmark* — and
+even that is naturally an array parameter.
+
+## Existing building blocks (already in the codebase)
+
+- **Flags + auto thresholds:** `src/types/images.ts` → `DiffusionServerConfig`
+  (`clipOnCpu`, `vaeOnCpu`, `offloadToCpu`, `diffusionFlashAttention`, `batchSize`,
+  `threads`, `forceValidation`). Auto-detection lives in
+  `DiffusionServerManager.computeDiffusionOptimizations()`
+  (`src/managers/DiffusionServerManager.ts`), thresholds in
+  `src/config/defaults.ts` → `DIFFUSION_VRAM_THRESHOLDS`
+  (`clipOnCpuHeadroomBytes = 6 GiB`, `vaeOnCpuHeadroomBytes = 2 GiB`,
+  `modelOverheadMultiplier = 1.2`; `offloadToCpu` when footprint > 85% of VRAM).
+- **Per-generation execution:** `DiffusionServerManager.generateImage(config)`
+  (`ImageGenerationConfig` → `ImageGenerationResult`). `ImageGenerationResult`
+  already returns `timeTaken` (ms), `seed`, `width`, `height`.
+- **Per-stage timing already tracked internally** for progress estimation:
+  `DiffusionServerManager` keeps `loadStartTime/loadEndTime/diffusionStartTime/
+  diffusionEndTime` (~lines 1287–1299). Surfacing load/diffusion/decode as part of
+  the calibration result would make the sweep *diagnostic* (it directly shows
+  where a combo's cost lands: CPU-VAE → decode stage, CPU-CLIP → load/encode,
+  offload → diffusion stage).
+- **Config is start-time:** flags are read from `this._config` per generation, set
+  at `start()`. So each combo requires a **stop + start** with that config — the
+  sweep must orchestrate restarts. `start()` is cheap (no model preload; sd.cpp is
+  spawned per generation), so restarts are acceptable.
+  *(Resolution note: this premise turned out to be avoidable — flags are resolved
+  per generation, so the implementation threads per-combo overrides into each
+  spawn with no restarts at all.)*
+- **Prior art for internal test-gen:** `BinaryManager` Phase 2 already runs real
+  sd.cpp inference to validate GPU functionality (`src/managers/BinaryManager.ts`,
+  "Phase 2: Testing GPU functionality with real inference"). The calibration sweep
+  is a generalization of that idea.
+- **Machine fingerprint:** `SystemInfo.getGPUInfo()` → `GPUInfo`
+  (`src/types/system.ts`: `type`, `name`, `vram`, `vramAvailable`).
+
+## Proposed API
+
+A method on the diffusion server (mirrors how `start`/`generateImage` live there),
+plus exported types. A standalone exported `calibrateDiffusion(config)` wrapper is
+also fine.
+
+```ts
+/** One offload combination to benchmark. Omitted flag = auto-detect (undefined). */
+export interface DiffusionOffloadCombo {
+  label?: string;                     // e.g. "clip-off + offload-on"
+  clipOnCpu?: boolean;
+  vaeOnCpu?: boolean;
+  offloadToCpu?: boolean;
+  diffusionFlashAttention?: boolean;
+}
+
+export interface CalibrationSize { width: number; height: number; }
+
+export interface DiffusionCalibrationConfig {
+  modelId: string;
+  /** Sizes to benchmark. Default: a small representative set (see below). */
+  sizes?: CalibrationSize[];
+  /** Combos to benchmark. Default: the curated set below. */
+  combos?: DiffusionOffloadCombo[];
+  /** Inference steps per generation. Default: 4.
+   *  NB: offload cost scales with steps — prefer the caller's real step count. */
+  steps?: number;
+  cfgScale?: number;                  // default: model-appropriate
+  sampler?: ImageSampler;             // default: 'euler'
+  /** Fixed seed so every combo does identical work. Default: a constant. */
+  seed?: number;
+  /** Neutral benchmark prompt. Default provided. */
+  prompt?: string;
+  /** Timed samples per (size, combo), after 1 discarded warmup. Default: 2. */
+  samples?: number;
+  onProgress?: (p: DiffusionCalibrationProgress) => void;
+  signal?: AbortSignal;               // cancellable
+}
+
+export interface DiffusionCalibrationProgress {
+  phase: 'starting' | 'warmup' | 'sampling' | 'done';
+  sizeIndex: number; sizeCount: number;
+  comboIndex: number; comboCount: number;
+  sample?: number; sampleCount?: number;
+  overallPercent: number;
+}
+
+export interface CalibrationRun {
+  size: CalibrationSize;
+  combo: DiffusionOffloadCombo;       // as requested (undefined = auto)
+  /** What auto-detection resolved omitted flags to (for transparency). */
+  resolved?: { clipOnCpu: boolean; vaeOnCpu: boolean; offloadToCpu: boolean; diffusionFlashAttention: boolean };
+  status: 'ok' | 'oom' | 'error';
+  timeTakenMs?: number;               // median of samples (total wall-clock per image)
+  stageMs?: { loadMs?: number; diffusionMs?: number; decodeMs?: number };
+  samplesMs?: number[];               // raw per-sample totals (for variance)
+  error?: string;                     // when status != 'ok'
+}
+
+export interface DiffusionCalibrationReport {
+  machine: { gpuType?: string; gpuName?: string; vramBytes?: number; vramAvailableBytes?: number };
+  modelId: string;
+  steps: number;
+  runs: CalibrationRun[];
+  /** Fastest OK combo per size, keyed "<W>x<H>". Absent for a size where all failed. */
+  recommended: Record<string, DiffusionOffloadCombo>;
+}
+
+// On DiffusionServerManager (and the `diffusionServer` singleton):
+calibrate(config: DiffusionCalibrationConfig): Promise<DiffusionCalibrationReport>;
+```
+
+### Default sweep
+
+**Default sizes:** a small representative set, e.g. `[{768,768}]`, or
+`[{768,768},{512,1024}]`. Callers that commit to specific dimensions should pass
+their own — the optimum shifts with size (bigger latent → more VRAM pressure).
+
+**Default combos** (curated, ~6 — the full 2⁴ is wasteful and mostly dominated):
+
+1. `{}` — **auto** (baseline; current heuristic)
+2. `{ clipOnCpu: false }` — encoder on GPU
+3. `{ clipOnCpu: false, offloadToCpu: true }` — encoder on GPU + managed streaming *(the empirically-best combo above)*
+4. `{ offloadToCpu: true }` — auto clip + managed streaming
+5. `{ clipOnCpu: false, vaeOnCpu: false, offloadToCpu: false }` — everything resident (fastest if it fits, else OOM)
+6. `{ clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true }` — max VRAM saving (last-resort fallback so *something* runs on very tight VRAM)
+
+`diffusionFlashAttention` is left at auto in the default combos (auto-enables for
+Flux). It can be added as an optional extra axis by the caller.
+
+## Design considerations
+
+- **Restart per combo.** Flags are start-config → stop + start the server for each
+  combo. Cheap (no model preload). Do it once per combo, then run warmup + samples
+  at each size before moving on (minimizes restarts; sizes share a server config).
+  *(Resolution note: superseded — no restarts in the implementation.)*
+- **Timing methodology.** Fixed `seed`, `steps`, `cfgScale`, `sampler`, `prompt`,
+  and `size` so **every combo does identical work** — only device placement varies,
+  so wall-clock is the sole variable. One discarded **warmup** generation per combo
+  (stabilizes disk cache / first-spawn overhead), then `samples` timed runs; report
+  the **median** as `timeTakenMs` and keep raw `samplesMs`. Note: sd.cpp reloads
+  the model every generation, so model-load time is part of *every* real image and
+  should be **included** (representative) — surface the stage split so callers can
+  see load vs diffusion vs decode.
+- **OOM safety (must not abort the sweep).** Wrap each generation; on failure,
+  classify from sd.cpp stderr/exit (`out of memory`, `cudaMalloc`, `alloc`,
+  `CUDA error`, etc.) → `status: 'oom'`, else `'error'`. Continue to the next
+  combo. This is essential: on Linux, high-pressure combos hard-fail; on Windows
+  they run slowly (captured as a slow `'ok'`). The fallback combo (6) exists so at
+  least one combo succeeds on very tight VRAM.
+- **Determinism / equivalence.** Offload/clip/vae are **device-placement** flags;
+  they do not change the algorithm, so output images are equivalent across combos
+  (minor fp differences only). Therefore it is safe to pick the winner purely by
+  time. (One exception below — SD3.5-Large.)
+- **`recommended`** = fastest `status==='ok'` combo per size. Ties → prefer the
+  combo closest to auto (fewer forced flags) for robustness.
+- **Server state afterward.** Leave the server **stopped** (clean) so the caller
+  re-`ensure`s with the chosen config. Document this.
+- **Cancellation / progress.** Honour `signal` (abort between combos/samples and on
+  the in-flight generation via existing stop path). Emit `onProgress` so callers
+  can show a progress bar (sweep can take a few minutes).
+- **Optional caching.** genai-electron *may* cache a report keyed by
+  (`gpuName`+`vramBytes`, `modelId`, size, steps) to skip repeat sweeps, but the
+  primary contract is "return the report; the caller persists/applies it."
+  Recommend leaving persistence to the caller (keep this API pure).
+
+## Caveats / edge cases (document these)
+
+- **SD3.5-Large + `clipOnCpu` is broken** (garbled conditioning — leejet/
+  stable-diffusion.cpp#1578). The sweep should **skip `clipOnCpu=true` combos** for
+  that model family (genai-electron can detect it), or clearly document that the
+  caller must exclude them. This is the one case where a combo changes the *image*,
+  not just the time.
+- **Steps interaction.** `offloadToCpu` overhead scales with step count; calibrating
+  at few steps under-represents its cost. Prefer the caller's real `steps`.
+- **Size dependence.** Bigger images shift the optimum (more VRAM pressure); hence
+  per-size runs and per-size `recommended`.
+- **Measurement noise.** Thermal throttling and background GPU/CPU load perturb
+  timings; keep `samplesMs` raw so callers can see variance, and consider
+  interleaving combos if a single-combo burst risks thermal bias.
+
+## Non-goals
+
+- Image-**quality** comparison across combos (assumed equivalent; SD3.5 caveat aside).
+- Auto-**applying** or persisting the winner — the caller decides and stores it.
+- Tuning steps / sampler / cfg / resolution (only offload placement).
+- Multi-GPU selection and cloud/remote providers.
+
+## Acceptance criteria
+
+- `diffusionServer.calibrate(config)` runs the sweep across the given sizes × combos
+  and returns a `DiffusionCalibrationReport` with per-run `status`, `timeTakenMs`
+  (and stage split when available), plus a `recommended` combo per size.
+- Combos that OOM/error are **caught and recorded**, never abort the sweep; at least
+  the fallback combo yields a result on tight VRAM.
+- Fixed seed/steps/prompt/size make combos directly comparable.
+- Cancellable via `signal`; progress via `onProgress`; server left **stopped**.
+- SD3.5-Large excludes `clipOnCpu=true` combos automatically (or documented).
+- Docs updated: `genai-electron-docs/image-generation.md` (new "Calibration"
+  section) and `typescript-reference.md` (new types); changelog/migration note.
+- Unit/integration coverage: a mocked-spawn test that verifies the sweep restarts
+  per combo, classifies an injected OOM, and picks the fastest OK combo.
+
+## Intended consumer usage (context, not part of this API)
+
+A host app (e.g. a text-RPG GUI) that commits to specific illustration sizes will:
+
+```ts
+const report = await diffusionServer.calibrate({
+  modelId,
+  sizes: [{ width: 768, height: 768 }, { width: 512, height: 1024 }], // the app's real sizes
+  steps: 4,                                                            // the app's quality preset
+});
+// Persist report.recommended["768x768"] etc. into the app's per-model settings,
+// and pass those flags to future start()/ensure() calls.
+```
+
+The host already exposes manual `clipOnCpu/vaeOnCpu/offloadToCpu/flashAttention`
+overrides (Auto/On/Off); calibration is the "measure and fill them in for me"
+button. Everything above the `sizes` array is generic and lives here.

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -1,0 +1,487 @@
+# Plan: Diffusion Offload Calibration API (`diffusionServer.calibrate()`)
+
+Created: 2026-07-04
+Status: IN PROGRESS (approved 2026-07-04)
+Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion (agreed decisions below)
+
+## Phase status
+
+- [x] Phase 1: Types, defaults, core plumbing
+- [~] Phase 2: `calibrate()` implementation (code done; final gate = Phase 3 suite)
+- [~] Phase 3: Tests
+- [ ] Phase 4: Documentation + housekeeping
+- [ ] Phase 5: Example-app wiring
+- [ ] Phase 6: Live smoke
+- [ ] Final `/doublecheck`
+
+## Summary
+
+Add a per-machine calibration sweep to `DiffusionServerManager`: benchmark CPU-offload flag
+combinations (`clipOnCpu` / `vaeOnCpu` / `offloadToCpu` / `diffusionFlashAttention`) for a given
+model and image size(s) by actually running generations, and return a report with per-combo
+timings, per-stage splits, OOM/error classification, and a recommended (fastest working) combo
+per size. First-class progress reporting (callback **and** event) so callers can drive a
+progress bar.
+
+## Agreed design decisions (from review of the ISSUE)
+
+1. **No restarts.** The ISSUE assumed stop+start per combo, but flags are resolved *per
+   generation* (`computeDiffusionOptimizations()` is called inside `executeImageGeneration()`,
+   `src/managers/DiffusionServerManager.ts:842`). `calibrate()` threads per-combo flag overrides
+   directly into each spawn. No HTTP server, no port binding, no restart churn.
+2. **Server-state contract: require stopped.** `calibrate()` throws if the server is running.
+   It does its own minimal setup (model validation + `ensureBinary`, no HTTP server) and leaves
+   the server stopped. `start()` throws while a calibration is in flight.
+3. **LLM handling: sweep-level offload via orchestrator.** If the manager was constructed with a
+   `llamaServer` (→ internal `ResourceOrchestrator`), settle any in-flight background reload
+   (`await waitForReload()` — without this, an LLM mid-reload reads as not-running, the offload
+   no-ops, and the LLM comes back *during* the sweep), then offload the LLM **once**
+   (unconditionally if running — measurement hygiene) and restore it (awaited) at sweep end, in
+   a `finally`. Requires making `ResourceOrchestrator.offloadLLM()` / `reloadLLM()` public.
+   Note: `offloadLLM()` no-ops when the LLM isn't running but **throws** if it is running with
+   no retrievable config (`ResourceOrchestrator.ts:383`) — so the offload call must already be
+   inside calibrate's try/finally. `reloadLLM()` no-ops without saved state and never throws.
+   Without an orchestrator, document that the caller should stop the LLM first.
+4. **Abort: throw, with partial results attached.** On `signal` abort: cancel the in-flight
+   generation and throw a `ServerError`. **Discriminator caveat:** `ServerError` hardcodes its
+   top-level `.code` to `'SERVER_ERROR'`, so the abort marker lives in
+   `error.details.code === 'CALIBRATION_ABORTED'` with partial runs in `error.details.runs`
+   (consistent with how other details-carried codes work in this codebase; must be stated
+   verbatim in docs and asserted that way in tests).
+   *Deliberate divergence from the ISSUE:* the ISSUE suggested aborting "via existing stop
+   path", but `stop()` early-returns when `_status === 'stopped'` (`:278`) — which is the status
+   throughout calibration — so it would be a silent no-op. Calibrate aborts the in-flight
+   generation via `this.currentGeneration?.cancel()` directly. Do not "simplify" this back.
+5. **SD3.5-Large guard.** Detect via name/id pattern; skip `clipOnCpu: true` combos (both
+   default and caller-provided), record them in the report (`skippedCombos`), and document
+   (upstream leejet/stable-diffusion.cpp#1578 — changes the image, not just the time).
+6. **Defaults per the ISSUE:** curated 6-combo set, 1 discarded warmup per combo, 2 timed
+   samples, median reported + raw `samplesMs` (with `samples: 2` the median is the mean of the
+   two — documented), fixed seed/steps/prompt/sampler so combos do identical work. Default
+   sweep = 6 combos × (1 warmup + 2 samples × 1 size) = 18 generations.
+
+## Scope
+
+- **In scope:** `calibrate()` method + types + progress reporting; per-run flag-override
+  plumbing; OOM classification; `ResourceOrchestrator` public offload/reload; unit tests;
+  docs (image-generation, typescript-reference, resource-orchestration); PROGRESS entry;
+  ISSUE file resolution (move to `docs/dev/issues/`).
+- **Out of scope (per ISSUE non-goals):** image-quality comparison, auto-applying/persisting
+  the winner, tuning steps/sampler/cfg/resolution, multi-GPU, report caching inside the
+  library. The ISSUE's optional standalone `calibrateDiffusion()` wrapper is deliberately
+  omitted (the method on the manager/singleton suffices).
+- **Versioning:** deliberately deferred per the agreed release workflow — this lands as an
+  **unreleased** batch (PROGRESS.md "Unreleased" entry only). Version strings (package.json,
+  `src/index.ts` `@version`, README header) and any migration notes are bumped later in a
+  release PR, when the user explicitly says to release.
+
+---
+
+## API (new types in `src/types/images.ts`)
+
+```ts
+/** One offload combination to benchmark. Omitted flag = auto-detect. */
+export interface DiffusionOffloadCombo {
+  label?: string;                     // e.g. "clip-off + offload-on"
+  clipOnCpu?: boolean;
+  vaeOnCpu?: boolean;
+  offloadToCpu?: boolean;
+  diffusionFlashAttention?: boolean;
+}
+
+export interface CalibrationSize { width: number; height: number; }
+
+export interface DiffusionCalibrationConfig {
+  modelId: string;
+  sizes?: CalibrationSize[];          // default: [{ width: 768, height: 768 }]
+  combos?: DiffusionOffloadCombo[];   // default: curated set (below)
+  steps?: number;                     // default: 4 (docs: prefer the caller's real step count —
+                                      // offload cost scales with steps; 4 suits distilled models)
+  cfgScale?: number;                  // default: omitted → sd.cpp default
+  sampler?: ImageSampler;             // default: 'euler'
+  seed?: number;                      // default: 42 (fixed → identical work per combo)
+  prompt?: string;                    // default: neutral benchmark prompt
+  samples?: number;                   // timed samples per (combo, size); default: 2
+  threads?: number;                   // optional passthrough (match production -t)
+  batchSize?: number;                 // optional passthrough (match production -b)
+  onProgress?: (p: DiffusionCalibrationProgress) => void;
+  signal?: AbortSignal;
+}
+
+export interface DiffusionCalibrationProgress {
+  phase: 'preparing' | 'warmup' | 'sampling' | 'restoring-llm' | 'done';
+  comboIndex: number;                 // 0-based index into the active (post-skip) combo list
+  comboCount: number;                 // active combos (skipped ones excluded)
+  combo?: DiffusionOffloadCombo;      // current combo — UI text via combo.label (defaults are labeled)
+  sizeIndex: number;
+  sizeCount: number;
+  size?: CalibrationSize;
+  sample?: number;                    // 1-based, timed samples only
+  sampleCount?: number;
+  generationPercent?: number;         // 0-100 within the current generation (from sd.cpp progress)
+  overallPercent: number;             // 0-100 smooth across the whole sweep
+}
+
+export interface CalibrationRun {
+  size: CalibrationSize;
+  combo: DiffusionOffloadCombo;       // as requested (omitted = auto)
+  /** What auto-detection resolved omitted flags to (captured per run). */
+  resolved?: {
+    clipOnCpu: boolean; vaeOnCpu: boolean;
+    offloadToCpu: boolean; diffusionFlashAttention: boolean;
+  };
+  status: 'ok' | 'oom' | 'error';
+  timeTakenMs?: number;               // median of samplesMs; only when status === 'ok'
+  stageMs?: { loadMs?: number; diffusionMs?: number; decodeMs?: number };
+  samplesMs?: number[];               // raw totals of *successful* samples (kept even on failed runs)
+  error?: string;                     // when status != 'ok'
+}
+
+export interface DiffusionCalibrationReport {
+  machine: { gpuType?: string; gpuName?: string; vramBytes?: number; vramAvailableBytes?: number };
+  modelId: string;
+  // Methodology echo (for caller-side persistence keying / reproducibility):
+  steps: number;
+  sampler: ImageSampler;
+  samples: number;
+  runs: CalibrationRun[];
+  /** Fastest OK combo per size, keyed "<W>x<H>" (e.g. "768x768" — document the exact format).
+   *  Value is the combo AS REQUESTED (winner may be `{}` = auto); what auto resolved to is in
+   *  the winning run's `resolved`. Absent for a size where all combos failed. */
+  recommended: Record<string, DiffusionOffloadCombo>;
+  /** Combos excluded up-front (e.g. SD3.5-Large + clipOnCpu). */
+  skippedCombos?: { combo: DiffusionOffloadCombo; reason: string }[];
+}
+```
+
+New method + helpers on `DiffusionServerManager`:
+
+```ts
+calibrate(config: DiffusionCalibrationConfig): Promise<DiffusionCalibrationReport>;
+isCalibrating(): boolean;
+```
+
+**Progress delivery (user requirement — progress bar):** both channels, same payload:
+- `config.onProgress(p)` callback (primary, same-process).
+- `'calibration-progress'` event on the manager (mirrors the `'binary-progress'` pattern →
+  natural to forward over IPC in Electron apps). Emit via raw `this.emit(...)` like
+  `'binary-progress'` (`ServerManager.ts:521`) — do NOT use the typed `emitEvent()`, which is
+  constrained to the `ServerEvent` union and would force a `servers.ts` change.
+- **Both guarded:** wrap the callback invocation and the `emit` in try/catch (swallow; debug-log)
+  so a throwing consumer cannot abort the sweep with a raw error.
+
+Defaults live in `src/config/defaults.ts` as `DIFFUSION_CALIBRATION_DEFAULTS` (exported):
+default combos, sizes, steps, samples, seed, prompt, tie tolerance, SD3.5-Large pattern,
+OOM stderr patterns.
+
+**Default combos** (curated, from the ISSUE — each ships with a `label` since progress UIs and
+persisted recommendations surface it):
+
+1. `{ label: 'auto' }` — baseline; current heuristic
+2. `{ label: 'clip-gpu', clipOnCpu: false }` — encoder on GPU
+3. `{ label: 'clip-gpu+offload', clipOnCpu: false, offloadToCpu: true }` — encoder on GPU + managed streaming (empirical best on 8 GB/Win11)
+4. `{ label: 'offload', offloadToCpu: true }` — auto clip + managed streaming
+5. `{ label: 'all-resident', clipOnCpu: false, vaeOnCpu: false, offloadToCpu: false }` — fastest if it fits, else OOM
+6. `{ label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true }` — fallback so something runs
+
+`diffusionFlashAttention` stays at auto in defaults (callers may add it as an extra axis).
+`label` is ignored by flag resolution (only the four flag fields are read).
+
+---
+
+## Phases
+
+### Phase 1: Types, defaults, core plumbing
+
+**Goal:** Everything `calibrate()` will need, landed first so each phase compiles on its own.
+
+**Work:**
+- [x] Add the six types above to `src/types/images.ts`; re-export via `src/types/index.ts` and
+  `src/index.ts` (type-exports block).
+- [x] Add `DIFFUSION_CALIBRATION_DEFAULTS` to `src/config/defaults.ts` (combos with labels, sizes,
+  steps, samples, seed, prompt, tie tolerance %, SD3.5-Large id/name pattern, OOM stderr
+  patterns); export from `src/index.ts` (constants block).
+- [x] `computeDiffusionOptimizations(flagOverrides?: DiffusionOffloadCombo)` — precedence per flag:
+  `flagOverrides.X ?? serverConfig.X ?? autoX`. No behavior change when called without overrides.
+- [x] `executeImageGeneration(config, flagOverrides?)` — optional second param, passed through.
+  Existing callers (orchestrator, batch, async path) unchanged.
+- [x] Store the resolved flags in a private `lastResolvedOptimizations` field (read by calibrate
+  after each run for `CalibrationRun.resolved`).
+- [x] `ResourceOrchestrator`: make `offloadLLM()` and `reloadLLM()` public with JSDoc (no logic
+  change). JSDoc must be precise: `offloadLLM()` no-ops when the LLM isn't running but throws
+  if running without a retrievable config; `reloadLLM()` no-ops without saved state and never
+  throws (internally retried + swallowed).
+
+**Verification:**
+- [x] `npm run build` — 0 errors; all existing tests still pass (543/543; the "worker process
+  failed to exit gracefully" Jest warning was verified pre-existing on the unmodified tree).
+  Note: Phase 1 alone did not compile standalone (TS6133 — `lastResolvedOptimizations`
+  write-only until calibrate() reads it), so the build gate ran after Phase 2's code, as one
+  compile unit.
+
+### Phase 2: `calibrate()` implementation
+
+**Goal:** The sweep itself.
+
+**Work — control flow:**
+1. **Guards:** throw `ServerError` if `_status !== 'stopped'`; throw if already calibrating
+   (private `calibrating` flag, set here). Add matching guard in `start()` (throw while
+   calibrating). Check `signal.aborted` at entry (throw `CALIBRATION_ABORTED` immediately, empty
+   `details.runs`). Validate `sizes`: positive integers, multiples of 64 (sd.cpp constraint) —
+   clear `ServerError` up-front beats a cryptic per-run failure.
+   Note (no extra guard needed, confirm in tests): during calibration `_status` stays
+   `'stopped'`, so a stray `stop()` no-ops and `generateImage()` throws "not running";
+   `getInfo().busy` may read `true` mid-generation — harmless, mention in docs.
+2. **Setup (phase `'preparing'`):** `getModelInfo` + diffusion-type check; `canRunModel`
+   (`checkTotalMemory: true`); initialize log manager (`diffusion-server.log`) if absent;
+   `ensureBinary` (reuses existing multi-component test-args logic). **First-run caveat:**
+   `ensureBinary` may download ~50–660 MB + run validation inference; it already emits
+   `'binary-progress'`/`'binary-log'` on this manager — docs tell callers to subscribe for that
+   phase; check `signal.aborted` immediately after it returns.
+   Save prior `_config` / `currentModelInfo` / `binaryPath`; install synthetic
+   `_config = { modelId, threads?, batchSize? }` + fresh `currentModelInfo` / `binaryPath`.
+   (Required: `computeDiffusionOptimizations` dereferences `this._config` at `:1036`/`:1078` —
+   the *first* crash site with `_config === undefined` — and `buildDiffusionArgs` reads
+   `.threads` at `:1182`. This holds even for pure-auto combos, since precedence still evaluates
+   `serverConfig.X`.) All state from here on is torn down in `finally`.
+3. **LLM offload:** `await this.orchestrator?.waitForReload()` (settle any background reload
+   from a prior orchestrated generation — otherwise the LLM can read as not-running now and
+   come back mid-sweep), then `await this.orchestrator?.offloadLLM()`.
+4. **Combo list:** caller's or default. If model id/name matches the SD3.5-Large pattern,
+   filter out combos with `clipOnCpu === true` → `skippedCombos` with reason + log line.
+   `comboCount`/progress accounting use the post-filter (active) list.
+5. **Sweep loop** (combo-outer, size-inner; sizes processed in caller order):
+   - Per combo: 1 warmup generation at the first size (discarded), then per size: `samples`
+     timed generations. Every generation uses fixed seed/steps/cfg/sampler/prompt and
+     `executeImageGeneration(genConfig, combo)`.
+   - **Bookkeeping invariant:** every (active combo × size) pair produces exactly one
+     `CalibrationRun`.
+   - After each generation (warmup included): read `lastResolvedOptimizations` → `resolved`;
+     snapshot the stage timestamps (`loadStartTime`/`loadEndTime`, `diffusionStartTime`/
+     `diffusionEndTime`, `vaeStartTime`/`vaeEndTime`) **per sample** — they are instance fields
+     reset by the next generation — into `{ loadMs, diffusionMs, decodeMs }` (fields omitted
+     when markers were missed).
+   - `timeTakenMs` = median of `samplesMs` (mean of middle two for even n), set only when
+     `status === 'ok'`; run's `stageMs` = the snapshot of the sample whose total is closest to
+     the median.
+   - **Failure handling (never aborts the sweep):** classify each failed generation via
+     stderr/exit-code patterns (`details.stderr`, `details.exitCode` on the `ServerError` from
+     `executeImageGeneration`) → `'oom'` (patterns: `out of memory`, `cudaMalloc`,
+     `CUDA error`, `ErrorOutOfDeviceMemory`, `failed to allocate`, `not enough memory`, …)
+     else `'error'` (spawn failures and pattern misses — incl. Windows access-violation exits
+     with empty stderr — classify `'error'`; still never recommended, so the report stays
+     correct; Windows over-subscription typically shows up as a slow `'ok'`, not a crash).
+     Rules:
+     - Timed sample fails → that (combo, size) run gets the failure status + `error`;
+       successful `samplesMs` are kept for diagnostics; remaining samples for that size are
+       skipped (an intermittently-failing combo must not be recommended); later sizes for the
+       combo are still attempted.
+     - Warmup fails → the **first size's** run records the failure (its timed samples are
+       skipped); later sizes are still attempted, without an extra warmup (failure at one size
+       doesn't imply failure at another).
+     - Progress accounting: units skipped due to failure are counted as **completed** so
+       `overallPercent` still reaches 100 by folding (no stall-then-jump).
+6. **Recommendation:** pure helper `pickRecommended(runs, tolerancePct)` — per size: fastest
+   `status === 'ok'` run; any run within 5% of the fastest with **fewer forced flags** (count
+   of defined flag fields, `label` excluded) wins the tie (robustness preference, per ISSUE,
+   made deterministic). Must be directly unit-testable (exported or `@internal`-exported —
+   decide at implementation).
+7. **Abort:** check `signal.aborted` before each generation; `signal` listener calls
+   `this.currentGeneration?.cancel()`. On abort: throw `ServerError` with
+   `details.code = 'CALIBRATION_ABORTED'` and `details.runs` = partial runs (see decision 4 —
+   top-level `.code` is `'SERVER_ERROR'`). Listener removed in finally.
+8. **Finally:** restore saved `_config`/`currentModelInfo`/`binaryPath`; phase
+   `'restoring-llm'` → `await this.orchestrator?.reloadLLM()`; `calibrating = false`; server
+   remains stopped.
+9. **Report:** `machine` from `systemInfo.getGPUInfo()` (`type`, `name`, `vram`,
+   `vramAvailable`); methodology echo (`steps`, `sampler`, `samples`); `runs`, `recommended`,
+   `skippedCombos`.
+
+**Work — progress (user requirement):**
+- Total work units = Σ over **active** combos of `(1 warmup + samples × sizeCount)`; units
+  skipped by failure handling count as completed (see 5).
+- Each generation's `onProgress` percentage is mapped to `generationPercent` and folded into
+  `overallPercent = (completedUnits + generationPercent/100) / totalUnits × 100` → the bar
+  moves smoothly *within* each generation, not just between runs.
+- Emit on: sweep start (`'preparing'`, 0%), every wrapped per-generation progress tick, each
+  warmup/sample boundary, `'restoring-llm'`, and `'done'` (100%) on success.
+- Deliver via both `config.onProgress` and the `'calibration-progress'` event; both guarded
+  with try/catch (a throwing consumer must not kill the sweep).
+
+**Tracking (Phase 2):**
+- [x] Guards (`stopped` required, `calibrating` flag, `start()` guard, pre-aborted signal, size validation)
+- [x] Setup / `'preparing'` (model+canRun+logManager+ensureBinary, save/install state)
+- [x] LLM offload (`waitForReload()` → `offloadLLM()`)
+- [x] Combo list + SD3.5-Large filter → `skippedCombos`
+- [x] Sweep loop (warmup + samples, per-sample stage snapshots, failure classification rules)
+- [x] `pickRecommended` pure helper (5% tolerance, fewer-forced-flags tie-break; exported `@internal`)
+- [x] Abort wiring (listener → `currentGeneration.cancel()`, `details.code = 'CALIBRATION_ABORTED'` + `details.runs`)
+- [x] Finally teardown (state restore, `'restoring-llm'` → `reloadLLM()`, `calibrating = false`)
+- [x] Report assembly (machine fingerprint, methodology echo, runs, recommended, skippedCombos)
+- [x] Progress plumbing (units math, `generationPercent` folding with monotonic clamp, guarded callback + `'calibration-progress'` event)
+
+**Verification:**
+- [x] `npm run build` — 0 TypeScript errors (strict mode).
+- [ ] Full unit-test suite (Phase 3) green.
+
+### Phase 3: Tests
+
+**Goal:** Coverage for the new surface.
+
+**Work:**
+- New test file `tests/unit/diffusion-calibration.test.ts` (reuses the mock scaffold from
+  `DiffusionServerManager.test.ts` — mocked spawn with controllable stdout/stderr/exit; the
+  scaffold's mock set is sufficient for the real-`ResourceOrchestrator` path, since the
+  orchestrator's own imports pull nothing needing extra mocks). Cases:
+  - [ ] Sweep spawns combos × (warmup + samples × sizes) processes; per-spawn CLI flags match each
+    combo (per-run flag resolution — replaces the ISSUE's obsolete "restarts per combo" check).
+  - [ ] Injected OOM (exit 1 + `CUDA error: out of memory` stderr) on one combo → `status: 'oom'`,
+    sweep continues, other combos recorded `'ok'`.
+  - [ ] Injected generic failure → `status: 'error'`.
+  - [ ] Warmup failure → first size's run carries the failure, later sizes still attempted,
+    progress still reaches 100.
+  - [ ] `pickRecommended`: fastest wins; 5%-tolerance tie prefers fewer forced flags; size with all
+    failures absent from `recommended` (pure-function tests with synthetic runs — deterministic,
+    no wall-clock dependence).
+  - [ ] Progress: phases observed in order, `overallPercent` monotonic 0→100, `'done'` emitted;
+    `'calibration-progress'` event fires with the same payloads as the callback; a **throwing**
+    `onProgress` does not abort the sweep.
+  - [ ] Abort mid-sweep → rejects with `details.code === 'CALIBRATION_ABORTED'` (top-level code is
+    `'SERVER_ERROR'`), partial `details.runs` present, `calibrating` cleared. Pre-aborted
+    signal at call time → immediate rejection, no spawns.
+  - [ ] Throws if server running; `start()` throws during calibration; invalid sizes (non-multiple
+    of 64) rejected up-front.
+  - [ ] SD3.5-Large model name → `clipOnCpu: true` combos in `skippedCombos`, not run.
+  - [ ] Constructed with mock `llamaServer` running → `llamaServer.stop()` once at sweep start,
+    `llamaServer.start()` (restore) at sweep end (exercises the real orchestrator with mocks:
+    `isRunning`, `getConfig`, `stop`, `start`).
+  - [ ] State restore: prior `_config`/`currentModelInfo`/`binaryPath` back in place after the
+    sweep (e.g. a normal `start()` + `generateImage()` works unchanged afterwards).
+- `computeDiffusionOptimizations` override-precedence cases can be covered through the sweep
+  tests (flags on spawn args); add a direct case in the existing test file only if a gap remains.
+
+**Verification:**
+- [ ] `npm test` — all suites green (543 existing + new).
+- [ ] `npm run lint`, `npm run format` clean.
+
+### Phase 4: Documentation + housekeeping
+
+**Goal:** Docs are a deliverable, not an afterthought.
+
+**Work:**
+- [ ] `genai-electron-docs/image-generation.md` — new **"Offload Calibration"** section (named to
+  avoid colliding with the existing "Self-Calibrating Estimates" progress section; add a
+  one-line cross-reference disambiguating the two): motivation (one short paragraph — the
+  optimum is machine-dependent), API + example (mirroring the ISSUE's consumer usage),
+  defaults, contract (server must be stopped and is left stopped; LLM offloaded/restored
+  automatically when orchestration is wired, else stop it yourself; report is returned, caller
+  persists/applies; `recommended` values are as-requested combos — see the winning run's
+  `resolved` for what auto picked; `"<W>x<H>"` key format), caveats (SD3.5-Large skip; steps
+  interaction — calibrate at your real step count; size dependence; sizes must be multiples of
+  64; thermal noise / raw `samplesMs`; first-run binary provisioning during `'preparing'` →
+  subscribe to `'binary-progress'`; `busy` may read true while status is `'stopped'`),
+  abort semantics (`details.code === 'CALIBRATION_ABORTED'`, `details.runs`), progress-bar
+  wiring snippet (callback + `'calibration-progress'` IPC forwarding). Add
+  `'calibration-progress'` to the **Events** list in the same file.
+- [ ] `genai-electron-docs/typescript-reference.md` — new types under "Image Generation Types"
+  (+ navigation entries); `DIFFUSION_CALIBRATION_DEFAULTS` under Constants.
+- [ ] `genai-electron-docs/resource-orchestration.md` — document now-public
+  `offloadLLM()`/`reloadLLM()`.
+- [ ] `PROGRESS.md` — "Unreleased" entry (no version bump, per release workflow).
+- [ ] Move `ISSUE-diffusion-offload-calibration.md` → `docs/dev/issues/`, add a resolution header
+  (implemented, date) listing **all** deviations: no-restart design; abort throws with partial
+  runs in `details` (code in `details.code`); 5% tie tolerance; progress phase enum reworked
+  (`'starting'` → `'preparing'`, added `'restoring-llm'`) and payload enriched
+  (`combo`/`size`/`sample`/`generationPercent`); `skippedCombos` + methodology echo on the
+  report; `isCalibrating()` added; standalone `calibrateDiffusion()` wrapper omitted;
+  labeled default combos.
+
+**Verification:**
+- [ ] Docs examples spot-checked against the final API (types, error discriminator, key format).
+- [ ] `npm run format` after doc edits.
+
+### Phase 5: Example-app wiring (confirmed in scope)
+
+**Goal:** Demonstrate the progress-bar consumer pattern in `examples/electron-control-panel`.
+
+**Work:** "Calibrate" button on the Diffusion Server tab; IPC handler calling
+`diffusionServer.calibrate()` with the form's model + a small size set; forward
+`'calibration-progress'` over IPC (pairs with the existing `'binary-progress'` follow-up);
+render a progress bar + result table; display `recommended` and let the user apply it to the
+form's Auto/On/Off overrides.
+
+**Tracking (Phase 5):**
+- [ ] IPC handler + preload wiring (`diffusion:calibrate`, cancel path)
+- [ ] `'calibration-progress'` forwarded over IPC
+- [ ] Calibrate button + progress bar + result table in DiffusionServerControl
+- [ ] Apply-recommended → Auto/On/Off override controls
+
+**Verification:**
+- [ ] Example app builds; manual click-through.
+
+### Phase 6: Live smoke (this machine)
+
+**Goal:** Reproduce the ISSUE's empirical table through the new API.
+
+**Work:** Small script (scratchpad) against the built library: Flux 2 Klein (Q4_0),
+`sizes: [{768,768}]`, real step count 4, default combos. Expect: combo 3
+(`clip-gpu+offload`) fastest or tied; `vaeOnCpu` combo markedly slower; auto baseline
+mid-pack; progress callback stream sane (monotonic, phases in order); LLM offload/restore
+observed if llama server running. **Single heavy-compute run in the main thread — no parallel
+agents running GPU work.**
+
+**Verification:**
+- [ ] Report matches the empirical shape from the ISSUE (directionally).
+- [ ] Server left stopped; subsequent normal `start()` + generation works.
+
+---
+
+## Files touched (summary)
+
+| File | Change |
+|---|---|
+| `src/types/images.ts` | +6 calibration types (Phase 1) |
+| `src/types/index.ts` | re-exports (Phase 1) |
+| `src/index.ts` | type + constant exports (Phase 1) |
+| `src/config/defaults.ts` | `DIFFUSION_CALIBRATION_DEFAULTS` (labeled combos, sizes, steps, samples, seed, prompt, tie tolerance, SD3.5 pattern, OOM patterns) (Phase 1) |
+| `src/managers/DiffusionServerManager.ts` | flag-override plumbing + `lastResolvedOptimizations` (Phase 1); `calibrate()`, `isCalibrating()`, `pickRecommended`, start() guard, `'calibration-progress'` event (Phase 2) |
+| `src/managers/ResourceOrchestrator.ts` | `offloadLLM()`/`reloadLLM()` private → public (Phase 1) |
+| `tests/unit/diffusion-calibration.test.ts` | new suite (Phase 3) |
+| `genai-electron-docs/{image-generation,typescript-reference,resource-orchestration}.md` | new sections (Phase 4) |
+| `PROGRESS.md` | Unreleased entry (Phase 4) |
+| `ISSUE-diffusion-offload-calibration.md` | → `docs/dev/issues/` with resolution note (Phase 4) |
+| `examples/electron-control-panel/*` | Calibrate button, IPC forwarding, progress bar + results UI (Phase 5) |
+
+No new dependencies (Node built-ins + existing internals only). No `servers.ts` change needed
+(`'calibration-progress'` is raw-emitted, matching the `'binary-progress'` precedent).
+
+## Risks
+
+- **Timing noise in unit tests** — avoided by testing winner-picking as a pure function;
+  sweep tests assert structure/flags/statuses, never wall-clock ordering.
+- **Shared mutable state** (`_config`, `currentModelInfo`, progress fields) — calibrate is
+  strictly sequential and exclusive (`calibrating` flag + `start()` guard); save/restore in
+  `finally`; stage-timestamp snapshots taken per sample before the next generation resets them.
+- **`updateTimeEstimates` cross-talk** — calibration runs feed the self-calibrating progress
+  estimators (`modelLoadTime` etc.). Harmless (they're heuristics that adapt anyway); noted,
+  not mitigated.
+- **OOM pattern coverage** — Windows access-violation crashes may produce no stderr; they
+  classify as `'error'`, which is still "not recommended", so the report stays correct.
+- **Steps default (4) under-represents offload cost at high step counts** — disclosed in docs
+  ("prefer your real step count", per the ISSUE); default suits distilled models (Turbo/Klein).
+
+## Branch / release
+
+Work on `feat/diffusion-calibration`; **no version bump now** — this accumulates as unreleased
+work per the agreed release workflow (PROGRESS.md "Unreleased" entry in Phase 4 is the only
+version-adjacent change). When the user later says to release: one release PR bumps
+package.json / `src/index.ts` `@version` / README, adds the PROGRESS release entry and any
+migration notes, then tag → GitHub release → user runs `npm publish`. Merge/PR timing decided
+by the user at the end.
+
+## Open questions
+
+None — Phase 5 confirmed in scope (2026-07-04).
+
+---
+**Approved 2026-07-04 — execution in progress on `feat/diffusion-calibration`. This file is the live tracker.**

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -1,14 +1,14 @@
 # Plan: Diffusion Offload Calibration API (`diffusionServer.calibrate()`)
 
 Created: 2026-07-04
-Status: IN PROGRESS (approved 2026-07-04)
+Status: COMPLETE (2026-07-04) — all phases done, live smoke PASSED, doublecheck clean; ships unreleased per the batch workflow
 Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion (agreed decisions below)
 
 ## Phase status
 
 - [x] Phase 1: Types, defaults, core plumbing
 - [x] Phase 2: `calibrate()` implementation
-- [x] Phase 3: Tests (20 new; 563/563 total, 22 suites)
+- [x] Phase 3: Tests (20 new; +3 in doublecheck hardening → 566/566 total, 22 suites)
 - [x] Phase 4: Documentation + housekeeping
 - [x] Phase 5: Example-app wiring
 - [x] Phase 6: Live smoke (PASSED 2026-07-04 — see Phase 6 results)

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -12,7 +12,19 @@ Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion
 - [x] Phase 4: Documentation + housekeeping
 - [x] Phase 5: Example-app wiring
 - [x] Phase 6: Live smoke (PASSED 2026-07-04 — see Phase 6 results)
-- [~] Final `/doublecheck`
+- [x] Final `/doublecheck` (2026-07-04): 3 read-only Opus reviewers (core impl / API+docs /
+  example+tests) + main-thread CI gate. **Verdict: faithful to plan & ISSUE, zero
+  critical/important findings.** Minor hardening applied same-day: `calibrating` released
+  before the awaited `reloadLLM()` (lock-safety), per-sweep combo copies (no shared refs to
+  `DIFFUSION_CALIBRATION_DEFAULTS.combos` in reports), calibration log writes made
+  fire-and-forget (match `executeImageGeneration`), IPC double-calibrate guard in the example,
+  +3 tests closing reviewer gaps (stdout-driven `stageMs`/fractional progress, happy-path
+  median of 2 samples + combo-copy lock-in, calibrate-during-calibrate guard) → 566/566,
+  and doc polish (docs index feature bullet, troubleshooting → calibrate cross-ref,
+  CLAUDE.md Key Exports line). Not addressed (accepted): internal-only
+  `orchestrateImageGeneration`-during-calibrate misuse (unreachable from public surface),
+  exit-code-based OOM classification (message/stderr matching suffices), pre-existing docs
+  catch-narrowing style, pre-existing preload `WindowAPI` missing image `cancel` (unrelated).
 
 ## Summary
 

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -11,8 +11,8 @@ Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion
 - [x] Phase 3: Tests (20 new; 563/563 total, 22 suites)
 - [x] Phase 4: Documentation + housekeeping
 - [x] Phase 5: Example-app wiring
-- [~] Phase 6: Live smoke
-- [ ] Final `/doublecheck`
+- [x] Phase 6: Live smoke (PASSED 2026-07-04 — see Phase 6 results)
+- [~] Final `/doublecheck`
 
 ## Summary
 
@@ -441,8 +441,39 @@ observed if llama server running. **Single heavy-compute run in the main thread 
 agents running GPU work.**
 
 **Verification:**
-- [ ] Report matches the empirical shape from the ISSUE (directionally).
-- [ ] Server left stopped; subsequent normal `start()` + generation works.
+- [x] Report matches the empirical shape from the ISSUE (directionally).
+- [x] Server left stopped; subsequent normal `start()` + generation works.
+
+**Results (2026-07-04, RTX 4060 Laptop 8 GB, flux-2-klein-q40, 768×768 @ 4 steps, euler,
+2 samples, ~12.5 min sweep):**
+
+| Combo | Median | diffusion / decode |
+|---|---|---|
+| `auto` (→ clip=true) | 33.5 s | 8.7 s / 1.4 s |
+| **`clip-gpu`** (recommended) | **17.1 s** | 9.2 s / 4.9 s |
+| `clip-gpu+offload` | 17.4 s | 11.3 s / 1.5 s |
+| `offload` | 57.5 s | 10.9 s / 1.5 s |
+| `all-resident` | 16.9 s | 8.8 s / 5.0 s |
+| `max-savings` | 97.3 s | 10.4 s / 66.4 s |
+
+- Auto heuristic beaten ~2×; `vaeOnCpu` decode trap confirmed (66 s); `offload`-alone worse
+  than auto — all directionally per the ISSUE. Divergence (the point of calibrating): on this
+  box at Q4_0/768², `clip=false` needs no `offloadToCpu` (`all-resident` ran clean at 16.9 s).
+- **Tie-break exercised live**: `all-resident` (16.9 s, 3 forced flags), `clip-gpu` (17.1 s,
+  1 flag), `clip-gpu+offload` (17.4 s, 2 flags) all within the 5% window → fewest-forced-flags
+  rule picked `clip-gpu`. Exactly as designed.
+- Progress: monotonic ✓ (asserted in-script), phases `preparing → (warmup → sampling)×6 →
+  restoring-llm → done` ✓, 2303 events on the `'calibration-progress'` channel (callback parity) ✓.
+- Post-check: normal `start()` with recommended flags + 768² generation OK (17.7 s, valid
+  1.29 MB PNG); server stopped cleanly; `isCalibrating()` false; status `stopped` after sweep.
+- `stageMs.loadMs` absent in all runs (loading-stage start marker not hit for this
+  multi-component model); `diffusionMs`/`decodeMs` present. Field is optional per spec — OK,
+  noted as a possible future parser follow-up.
+- Smoke ran as a headless Electron script sharing the example app's userData (v0.10.0 smoke
+  methodology). Gotcha for next time: **Electron 35's default app hangs silently on `.mjs`
+  entry scripts** — use a `.cjs` entry + dynamic `import()` of the ESM library. Scripts were
+  temporary (example dir, deleted after the run); full log in the session scratchpad
+  (`calibration-smoke2.log`).
 
 ---
 

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -10,8 +10,8 @@ Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion
 - [x] Phase 2: `calibrate()` implementation
 - [x] Phase 3: Tests (20 new; 563/563 total, 22 suites)
 - [x] Phase 4: Documentation + housekeeping
-- [~] Phase 5: Example-app wiring
-- [ ] Phase 6: Live smoke
+- [x] Phase 5: Example-app wiring
+- [~] Phase 6: Live smoke
 - [ ] Final `/doublecheck`
 
 ## Summary
@@ -415,13 +415,19 @@ render a progress bar + result table; display `recommended` and let the user app
 form's Auto/On/Off overrides.
 
 **Tracking (Phase 5):**
-- [ ] IPC handler + preload wiring (`diffusion:calibrate`, cancel path)
-- [ ] `'calibration-progress'` forwarded over IPC
-- [ ] Calibrate button + progress bar + result table in DiffusionServerControl
-- [ ] Apply-recommended → Auto/On/Off override controls
+- [x] IPC handler + preload wiring (`diffusion:calibrate` + `diffusion:calibrateCancel`;
+  main holds the AbortController and converts CALIBRATION_ABORTED into `{aborted, runs}`)
+- [x] `'calibration-progress'` forwarded over IPC (genai-api.ts, mirrors binary-log pattern)
+- [x] Calibrate button + progress bar + result table in DiffusionServerControl (card shown
+  while the server is stopped; benchmarks the Generate form's current size/steps; Start
+  disabled during sweeps)
+- [x] Apply-recommended → flags stored (label stripped) and spread into the next start()
+  (with a visible "on next start" hint + Clear; the app had no per-flag Auto/On/Off controls,
+  so apply-to-start-config is the equivalent)
 
 **Verification:**
-- [ ] Example app builds; manual click-through.
+- [x] Example app builds (tsc + vite, 0 errors); manual click-through folded into Phase 6
+  live smoke.
 
 ### Phase 6: Live smoke (this machine)
 

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -9,8 +9,8 @@ Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion
 - [x] Phase 1: Types, defaults, core plumbing
 - [x] Phase 2: `calibrate()` implementation
 - [x] Phase 3: Tests (20 new; 563/563 total, 22 suites)
-- [~] Phase 4: Documentation + housekeeping
-- [ ] Phase 5: Example-app wiring
+- [x] Phase 4: Documentation + housekeeping
+- [~] Phase 5: Example-app wiring
 - [ ] Phase 6: Live smoke
 - [ ] Final `/doublecheck`
 
@@ -371,7 +371,7 @@ persisted recommendations surface it):
 **Goal:** Docs are a deliverable, not an afterthought.
 
 **Work:**
-- [ ] `genai-electron-docs/image-generation.md` — new **"Offload Calibration"** section (named to
+- [x] `genai-electron-docs/image-generation.md` — new **"Offload Calibration"** section (named to
   avoid colliding with the existing "Self-Calibrating Estimates" progress section; add a
   one-line cross-reference disambiguating the two): motivation (one short paragraph — the
   optimum is machine-dependent), API + example (mirroring the ISSUE's consumer usage),
@@ -385,12 +385,12 @@ persisted recommendations surface it):
   abort semantics (`details.code === 'CALIBRATION_ABORTED'`, `details.runs`), progress-bar
   wiring snippet (callback + `'calibration-progress'` IPC forwarding). Add
   `'calibration-progress'` to the **Events** list in the same file.
-- [ ] `genai-electron-docs/typescript-reference.md` — new types under "Image Generation Types"
+- [x] `genai-electron-docs/typescript-reference.md` — new types under "Image Generation Types"
   (+ navigation entries); `DIFFUSION_CALIBRATION_DEFAULTS` under Constants.
-- [ ] `genai-electron-docs/resource-orchestration.md` — document now-public
+- [x] `genai-electron-docs/resource-orchestration.md` — document now-public
   `offloadLLM()`/`reloadLLM()`.
-- [ ] `PROGRESS.md` — "Unreleased" entry (no version bump, per release workflow).
-- [ ] Move `ISSUE-diffusion-offload-calibration.md` → `docs/dev/issues/`, add a resolution header
+- [x] `PROGRESS.md` — "Unreleased" entry (no version bump, per release workflow).
+- [x] Move `ISSUE-diffusion-offload-calibration.md` → `docs/dev/issues/`, add a resolution header
   (implemented, date) listing **all** deviations: no-restart design; abort throws with partial
   runs in `details` (code in `details.code`); 5% tie tolerance; progress phase enum reworked
   (`'starting'` → `'preparing'`, added `'restoring-llm'`) and payload enriched
@@ -399,8 +399,10 @@ persisted recommendations surface it):
   labeled default combos.
 
 **Verification:**
-- [ ] Docs examples spot-checked against the final API (types, error discriminator, key format).
-- [ ] `npm run format` after doc edits.
+- [x] Docs examples spot-checked against the final API (types, error discriminator, key format;
+  added a label-stripping note — spreading a labeled combo into start() would hit config
+  validation).
+- [x] `npm run format` after doc edits.
 
 ### Phase 5: Example-app wiring (confirmed in scope)
 

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -7,9 +7,9 @@ Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion
 ## Phase status
 
 - [x] Phase 1: Types, defaults, core plumbing
-- [~] Phase 2: `calibrate()` implementation (code done; final gate = Phase 3 suite)
-- [~] Phase 3: Tests
-- [ ] Phase 4: Documentation + housekeeping
+- [x] Phase 2: `calibrate()` implementation
+- [x] Phase 3: Tests (20 new; 563/563 total, 22 suites)
+- [~] Phase 4: Documentation + housekeeping
 - [ ] Phase 5: Example-app wiring
 - [ ] Phase 6: Live smoke
 - [ ] Final `/doublecheck`
@@ -322,7 +322,7 @@ persisted recommendations surface it):
 
 **Verification:**
 - [x] `npm run build` — 0 TypeScript errors (strict mode).
-- [ ] Full unit-test suite (Phase 3) green.
+- [x] Full unit-test suite (Phase 3) green.
 
 ### Phase 3: Tests
 
@@ -333,36 +333,38 @@ persisted recommendations surface it):
   `DiffusionServerManager.test.ts` — mocked spawn with controllable stdout/stderr/exit; the
   scaffold's mock set is sufficient for the real-`ResourceOrchestrator` path, since the
   orchestrator's own imports pull nothing needing extra mocks). Cases:
-  - [ ] Sweep spawns combos × (warmup + samples × sizes) processes; per-spawn CLI flags match each
+  - [x] Sweep spawns combos × (warmup + samples × sizes) processes; per-spawn CLI flags match each
     combo (per-run flag resolution — replaces the ISSUE's obsolete "restarts per combo" check).
-  - [ ] Injected OOM (exit 1 + `CUDA error: out of memory` stderr) on one combo → `status: 'oom'`,
+  - [x] Injected OOM (exit 1 + `CUDA error: out of memory` stderr) on one combo → `status: 'oom'`,
     sweep continues, other combos recorded `'ok'`.
-  - [ ] Injected generic failure → `status: 'error'`.
-  - [ ] Warmup failure → first size's run carries the failure, later sizes still attempted,
+  - [x] Injected generic failure → `status: 'error'`.
+  - [x] Warmup failure → first size's run carries the failure, later sizes still attempted,
     progress still reaches 100.
-  - [ ] `pickRecommended`: fastest wins; 5%-tolerance tie prefers fewer forced flags; size with all
+  - [x] `pickRecommended`: fastest wins; 5%-tolerance tie prefers fewer forced flags; size with all
     failures absent from `recommended` (pure-function tests with synthetic runs — deterministic,
     no wall-clock dependence).
-  - [ ] Progress: phases observed in order, `overallPercent` monotonic 0→100, `'done'` emitted;
+  - [x] Progress: phases observed in order, `overallPercent` monotonic 0→100, `'done'` emitted;
     `'calibration-progress'` event fires with the same payloads as the callback; a **throwing**
-    `onProgress` does not abort the sweep.
-  - [ ] Abort mid-sweep → rejects with `details.code === 'CALIBRATION_ABORTED'` (top-level code is
+    `onProgress` does not abort the sweep (also covers a throwing event listener).
+  - [x] Abort mid-sweep → rejects with `details.code === 'CALIBRATION_ABORTED'` (top-level code is
     `'SERVER_ERROR'`), partial `details.runs` present, `calibrating` cleared. Pre-aborted
-    signal at call time → immediate rejection, no spawns.
-  - [ ] Throws if server running; `start()` throws during calibration; invalid sizes (non-multiple
+    signal at call time → immediate rejection, no spawns. Plus: in-flight abort via the
+    cancel/kill path (hanging spawn + kill→exit wiring).
+  - [x] Throws if server running; `start()` throws during calibration; invalid sizes (non-multiple
     of 64) rejected up-front.
-  - [ ] SD3.5-Large model name → `clipOnCpu: true` combos in `skippedCombos`, not run.
-  - [ ] Constructed with mock `llamaServer` running → `llamaServer.stop()` once at sweep start,
+  - [x] SD3.5-Large model name → `clipOnCpu: true` combos in `skippedCombos`, not run.
+  - [x] Constructed with mock `llamaServer` running → `llamaServer.stop()` once at sweep start,
     `llamaServer.start()` (restore) at sweep end (exercises the real orchestrator with mocks:
     `isRunning`, `getConfig`, `stop`, `start`).
-  - [ ] State restore: prior `_config`/`currentModelInfo`/`binaryPath` back in place after the
-    sweep (e.g. a normal `start()` + `generateImage()` works unchanged afterwards).
+  - [x] State restore: prior `_config`/`currentModelInfo`/`binaryPath` back in place after the
+    sweep (e.g. a normal `start()` + `generateImage()` works unchanged afterwards; also
+    asserts no leftover combo overrides leak into post-calibration generations).
 - `computeDiffusionOptimizations` override-precedence cases can be covered through the sweep
   tests (flags on spawn args); add a direct case in the existing test file only if a gap remains.
 
 **Verification:**
-- [ ] `npm test` — all suites green (543 existing + new).
-- [ ] `npm run lint`, `npm run format` clean.
+- [x] `npm test` — all suites green (563/563: 543 existing + 20 new, 22 suites).
+- [x] `npm run lint` (0 errors, 62 pre-existing warnings), `npm run format` clean.
 
 ### Phase 4: Documentation + housekeeping
 

--- a/examples/electron-control-panel/main/genai-api.ts
+++ b/examples/electron-control-panel/main/genai-api.ts
@@ -95,6 +95,14 @@ export function setupServerEventForwarding(): void {
       }
     }
   );
+
+  // Offload-calibration sweep progress (same payload as calibrate()'s onProgress)
+  diffusionServer.on('calibration-progress', (data: unknown) => {
+    const mainWindow = BrowserWindow.getAllWindows()[0];
+    if (mainWindow) {
+      mainWindow.webContents.send('diffusion:calibration-progress', data);
+    }
+  });
 }
 
 /**

--- a/examples/electron-control-panel/main/ipc-handlers.ts
+++ b/examples/electron-control-panel/main/ipc-handlers.ts
@@ -344,6 +344,11 @@ export function registerIpcHandlers(): void {
         samples?: number;
       }
     ) => {
+      // Guard before creating a controller: a concurrent second call would
+      // otherwise orphan the running sweep's controller in the finally below
+      if (calibrationController !== null) {
+        throw new Error('Calibration is already in progress');
+      }
       try {
         calibrationController = new AbortController();
         const report = await diffusionServer.calibrate({

--- a/examples/electron-control-panel/main/ipc-handlers.ts
+++ b/examples/electron-control-panel/main/ipc-handlers.ts
@@ -328,6 +328,51 @@ export function registerIpcHandlers(): void {
     }
   });
 
+  // Offload calibration: benchmark clip/vae/offload flag combos on this machine.
+  // Progress reaches the renderer via the 'calibration-progress' event forwarding
+  // (see genai-api.ts); cancellation via an AbortController held here.
+  let calibrationController: AbortController | null = null;
+
+  ipcMain.handle(
+    'diffusion:calibrate',
+    async (
+      _event,
+      config: {
+        modelId: string;
+        sizes?: { width: number; height: number }[];
+        steps?: number;
+        samples?: number;
+      }
+    ) => {
+      try {
+        calibrationController = new AbortController();
+        const report = await diffusionServer.calibrate({
+          modelId: config.modelId,
+          sizes: config.sizes,
+          steps: config.steps,
+          samples: config.samples,
+          signal: calibrationController.signal,
+        });
+        return report;
+      } catch (error) {
+        const details = (error as { details?: { code?: string; runs?: unknown[] } }).details;
+        if (details?.code === 'CALIBRATION_ABORTED') {
+          // Aborted by the user — return the partial runs instead of throwing
+          return { aborted: true, runs: details.runs ?? [] };
+        }
+        throw new Error(`Calibration failed: ${(error as Error).message}`);
+      } finally {
+        calibrationController = null;
+      }
+    }
+  );
+
+  ipcMain.handle('diffusion:calibrateCancel', () => {
+    const active = calibrationController !== null;
+    calibrationController?.abort();
+    return { cancelling: active };
+  });
+
   // Generate image using genai-lite ImageService (with automatic orchestration)
   ipcMain.handle('diffusion:generate', async (_event, config) => {
     try {

--- a/examples/electron-control-panel/main/preload.ts
+++ b/examples/electron-control-panel/main/preload.ts
@@ -51,6 +51,8 @@ contextBridge.exposeInMainWorld('api', {
     generateImage: (config: unknown, port?: number) =>
       ipcRenderer.invoke('diffusion:generate', config, port),
     cancel: () => ipcRenderer.invoke('diffusion:cancel'),
+    calibrate: (config: unknown) => ipcRenderer.invoke('diffusion:calibrate', config),
+    calibrateCancel: () => ipcRenderer.invoke('diffusion:calibrateCancel'),
   },
 
   // Resource Orchestrator APIs (Phase 2)
@@ -85,6 +87,7 @@ contextBridge.exposeInMainWorld('api', {
       'diffusion:crashed',
       'diffusion:binary-log',
       'diffusion:progress',
+      'diffusion:calibration-progress',
     ];
 
     if (validChannels.includes(channel)) {
@@ -140,6 +143,8 @@ export type WindowAPI = {
     logs: (limit: number) => Promise<unknown[]>;
     clearLogs: () => Promise<void>;
     generateImage: (config: unknown, port?: number) => Promise<unknown>;
+    calibrate: (config: unknown) => Promise<unknown>;
+    calibrateCancel: () => Promise<{ cancelling: boolean }>;
   };
   resources: {
     wouldNeedOffload: () => Promise<boolean>;

--- a/examples/electron-control-panel/renderer/components/DiffusionServerControl.css
+++ b/examples/electron-control-panel/renderer/components/DiffusionServerControl.css
@@ -314,3 +314,39 @@
   background: rgba(33, 150, 243, 0.3);
   border-color: #2196f3;
 }
+
+/* Offload calibration results */
+.calibration-results {
+  margin-top: 16px;
+}
+
+.calibration-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-bottom: 12px;
+  color: #fff;
+}
+
+.calibration-table th,
+.calibration-table td {
+  padding: 6px 10px;
+  text-align: left;
+  border-bottom: 1px solid #3a3a3c;
+}
+
+.calibration-table th {
+  color: #8e8e93;
+  font-weight: 500;
+}
+
+.calibration-status-ok {
+  color: #2ecc71;
+  font-weight: 600;
+}
+
+.calibration-status-oom,
+.calibration-status-error {
+  color: #e74c3c;
+  font-weight: 600;
+}

--- a/examples/electron-control-panel/renderer/components/DiffusionServerControl.tsx
+++ b/examples/electron-control-panel/renderer/components/DiffusionServerControl.tsx
@@ -3,6 +3,7 @@ import Card from './common/Card';
 import StatusIndicator from './common/StatusIndicator';
 import ActionButton from './common/ActionButton';
 import Spinner from './common/Spinner';
+import ProgressBar from './common/ProgressBar';
 import { useDiffusionServer } from './hooks/useDiffusionServer';
 import { useModels } from './hooks/useModels';
 import type {
@@ -10,6 +11,10 @@ import type {
   ImageGenerationProgress,
   ImageSampler,
   BinaryLogEvent,
+  DiffusionOffloadCombo,
+  DiffusionCalibrationProgress,
+  DiffusionCalibrationReport,
+  CalibrationRun,
 } from '../types/api';
 import { MODEL_PRESETS } from '../data/model-presets';
 import type { PresetRecommendedSettings } from '../data/model-presets';
@@ -53,6 +58,20 @@ const DiffusionServerControl: React.FC = () => {
     null
   );
 
+  // Offload calibration state
+  const [calibrating, setCalibrating] = useState(false);
+  const [calibrationProgress, setCalibrationProgress] =
+    useState<DiffusionCalibrationProgress | null>(null);
+  const [calibrationReport, setCalibrationReport] = useState<DiffusionCalibrationReport | null>(
+    null
+  );
+  const [calibrationPartialRuns, setCalibrationPartialRuns] = useState<CalibrationRun[] | null>(
+    null
+  );
+  const [calibrationError, setCalibrationError] = useState('');
+  // Flags applied from a calibration recommendation, spread into the next start()
+  const [appliedFlags, setAppliedFlags] = useState<DiffusionOffloadCombo | null>(null);
+
   // Set first model as default when models load
   useEffect(() => {
     if (models.length > 0 && !selectedModel) {
@@ -83,6 +102,19 @@ const DiffusionServerControl: React.FC = () => {
 
     return () => {
       window.api.off('diffusion:progress');
+    };
+  }, []);
+
+  // Listen for offload-calibration progress events
+  useEffect(() => {
+    const handleCalibrationProgress = (data: DiffusionCalibrationProgress) => {
+      setCalibrationProgress(data);
+    };
+
+    window.api.on('diffusion:calibration-progress', handleCalibrationProgress);
+
+    return () => {
+      window.api.off('diffusion:calibration-progress');
     };
   }, []);
 
@@ -143,6 +175,8 @@ const DiffusionServerControl: React.FC = () => {
       await start({
         modelId: selectedModel,
         port: 8081,
+        // Offload flags from an applied calibration recommendation (if any)
+        ...(appliedFlags ?? {}),
       });
     } finally {
       setStartLoading(false);
@@ -201,6 +235,71 @@ const DiffusionServerControl: React.FC = () => {
     setGenerating(false);
     setGenerationProgress(null);
   };
+
+  const handleCalibrate = async () => {
+    if (!selectedModel) return;
+    setCalibrating(true);
+    setCalibrationError('');
+    setCalibrationReport(null);
+    setCalibrationPartialRuns(null);
+    setCalibrationProgress(null);
+    try {
+      // Benchmark at the Generate form's current size/steps (the settings that
+      // will actually be used) — everything else uses library defaults
+      const outcome = await window.api.diffusion.calibrate({
+        modelId: selectedModel,
+        sizes: [{ width, height }],
+        steps,
+      });
+      if ('aborted' in outcome) {
+        setCalibrationPartialRuns(outcome.runs);
+        setCalibrationError('Calibration cancelled — partial results below');
+      } else {
+        setCalibrationReport(outcome);
+      }
+    } catch (err) {
+      setCalibrationError((err as Error).message);
+    } finally {
+      setCalibrating(false);
+      setCalibrationProgress(null);
+    }
+  };
+
+  const handleCalibrateCancel = async () => {
+    try {
+      await window.api.diffusion.calibrateCancel();
+    } catch (err) {
+      setCalibrationError(`Cancel failed: ${(err as Error).message}`);
+    }
+  };
+
+  const applyRecommendedFlags = (combo: DiffusionOffloadCombo) => {
+    // Strip the label — it is a report/UI field, not a server-config field
+    const flags: DiffusionOffloadCombo = {};
+    if (combo.clipOnCpu !== undefined) flags.clipOnCpu = combo.clipOnCpu;
+    if (combo.vaeOnCpu !== undefined) flags.vaeOnCpu = combo.vaeOnCpu;
+    if (combo.offloadToCpu !== undefined) flags.offloadToCpu = combo.offloadToCpu;
+    if (combo.diffusionFlashAttention !== undefined) {
+      flags.diffusionFlashAttention = combo.diffusionFlashAttention;
+    }
+    setAppliedFlags(flags);
+  };
+
+  const formatCombo = (combo: DiffusionOffloadCombo): string => {
+    const parts: string[] = [];
+    if (combo.clipOnCpu !== undefined) parts.push(`clip-on-cpu=${combo.clipOnCpu ? 'on' : 'off'}`);
+    if (combo.vaeOnCpu !== undefined) parts.push(`vae-on-cpu=${combo.vaeOnCpu ? 'on' : 'off'}`);
+    if (combo.offloadToCpu !== undefined) {
+      parts.push(`offload=${combo.offloadToCpu ? 'on' : 'off'}`);
+    }
+    if (combo.diffusionFlashAttention !== undefined) {
+      parts.push(`diffusion-fa=${combo.diffusionFlashAttention ? 'on' : 'off'}`);
+    }
+    return parts.length > 0 ? parts.join(', ') : 'auto (no forced flags)';
+  };
+
+  const formatStageSeconds = (ms?: number): string =>
+    ms !== undefined ? `${(ms / 1000).toFixed(1)}s` : '—';
 
   // Match selected model to a preset for recommended settings
   const matchedPreset = MODEL_PRESETS.find((p) => selectedModel.startsWith(p.id));
@@ -336,11 +435,24 @@ const DiffusionServerControl: React.FC = () => {
           </div>
         )}
 
+        {appliedFlags && (
+          <div className="settings-hint">
+            <span>Calibrated offload flags on next start: {formatCombo(appliedFlags)}</span>
+            <button
+              type="button"
+              className="apply-preset-btn"
+              onClick={() => setAppliedFlags(null)}
+            >
+              Clear
+            </button>
+          </div>
+        )}
+
         <div className="server-actions">
           {!isRunning ? (
             <ActionButton
               onClick={handleStart}
-              disabled={startLoading || !selectedModel || models.length === 0}
+              disabled={startLoading || calibrating || !selectedModel || models.length === 0}
               variant="primary"
             >
               {startLoading ? (
@@ -373,6 +485,118 @@ const DiffusionServerControl: React.FC = () => {
           </p>
         )}
       </Card>
+
+      {/* Offload Calibration (server must be stopped) */}
+      {!isRunning && (
+        <Card title="Offload Calibration">
+          {calibrationError && (
+            <div className="error-banner">
+              <strong>Calibration:</strong> {calibrationError}
+            </div>
+          )}
+
+          <p className="info-message">
+            Benchmarks CPU-offload flag combinations (clip / vae / offload) on this machine with
+            real generations and recommends the fastest one. Uses the Generate form's current
+            settings: {width}×{height} at {steps} steps. Takes a few minutes; runs while the server
+            is stopped.
+          </p>
+
+          <div className="server-actions">
+            <ActionButton
+              onClick={handleCalibrate}
+              disabled={calibrating || startLoading || !selectedModel || models.length === 0}
+              variant="primary"
+            >
+              {calibrating ? (
+                <>
+                  <Spinner size="small" />
+                  Calibrating...
+                </>
+              ) : (
+                'Calibrate Offload Settings'
+              )}
+            </ActionButton>
+            {calibrating && (
+              <ActionButton onClick={handleCalibrateCancel} variant="danger">
+                Cancel
+              </ActionButton>
+            )}
+          </div>
+
+          {calibrating && calibrationProgress && (
+            <ProgressBar
+              current={Math.round(calibrationProgress.overallPercent)}
+              total={100}
+              label={`${calibrationProgress.phase}${
+                calibrationProgress.combo?.label ? ` — ${calibrationProgress.combo.label}` : ''
+              }${
+                calibrationProgress.sample
+                  ? ` (sample ${calibrationProgress.sample}/${calibrationProgress.sampleCount})`
+                  : ''
+              }`}
+            />
+          )}
+
+          {(calibrationReport || calibrationPartialRuns) && (
+            <div className="calibration-results">
+              <table className="calibration-table">
+                <thead>
+                  <tr>
+                    <th>Combo</th>
+                    <th>Status</th>
+                    <th>Time</th>
+                    <th>Load</th>
+                    <th>Diffusion</th>
+                    <th>Decode</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(calibrationReport?.runs ?? calibrationPartialRuns ?? []).map((run, idx) => (
+                    <tr key={idx}>
+                      <td>{run.combo.label ?? formatCombo(run.combo)}</td>
+                      <td className={`calibration-status-${run.status}`}>{run.status}</td>
+                      <td>{formatStageSeconds(run.timeTakenMs)}</td>
+                      <td>{formatStageSeconds(run.stageMs?.loadMs)}</td>
+                      <td>{formatStageSeconds(run.stageMs?.diffusionMs)}</td>
+                      <td>{formatStageSeconds(run.stageMs?.decodeMs)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              {calibrationReport &&
+                Object.entries(calibrationReport.recommended).map(([sizeKey, combo]) => (
+                  <div key={sizeKey} className="settings-hint">
+                    <span>
+                      Recommended for {sizeKey}:{' '}
+                      <strong>{combo.label ?? formatCombo(combo)}</strong> ({formatCombo(combo)})
+                    </span>
+                    <button
+                      type="button"
+                      className="apply-preset-btn"
+                      onClick={() => applyRecommendedFlags(combo)}
+                    >
+                      Apply
+                    </button>
+                  </div>
+                ))}
+              {calibrationReport && Object.keys(calibrationReport.recommended).length === 0 && (
+                <p className="warning-message">All combos failed — no recommendation available.</p>
+              )}
+              {calibrationReport?.skippedCombos && calibrationReport.skippedCombos.length > 0 && (
+                <p className="info-message">
+                  Skipped combos:{' '}
+                  {calibrationReport.skippedCombos
+                    .map((s) => s.combo.label ?? formatCombo(s.combo))
+                    .join(', ')}{' '}
+                  — {calibrationReport.skippedCombos[0].reason}
+                </p>
+              )}
+            </div>
+          )}
+        </Card>
+      )}
 
       {/* Image Generation Form */}
       {isRunning && (

--- a/examples/electron-control-panel/renderer/components/hooks/useDiffusionServer.ts
+++ b/examples/electron-control-panel/renderer/components/hooks/useDiffusionServer.ts
@@ -6,6 +6,11 @@ interface DiffusionServerConfig {
   port?: number;
   threads?: number;
   gpuLayers?: number;
+  // Offload flags (e.g. applied from an offload-calibration recommendation)
+  clipOnCpu?: boolean;
+  vaeOnCpu?: boolean;
+  offloadToCpu?: boolean;
+  diffusionFlashAttention?: boolean;
 }
 
 export function useDiffusionServer() {

--- a/examples/electron-control-panel/renderer/types/api.ts
+++ b/examples/electron-control-panel/renderer/types/api.ts
@@ -20,6 +20,11 @@ import type {
   DiffusionComponentRole,
   DiffusionComponentDownload,
   DiffusionModelComponents,
+  DiffusionOffloadCombo,
+  CalibrationSize,
+  CalibrationRun,
+  DiffusionCalibrationProgress,
+  DiffusionCalibrationReport,
 } from 'genai-electron';
 
 // Re-export library types for convenience
@@ -40,7 +45,18 @@ export type {
   DiffusionComponentRole,
   DiffusionComponentDownload,
   DiffusionModelComponents,
+  DiffusionOffloadCombo,
+  CalibrationSize,
+  CalibrationRun,
+  DiffusionCalibrationProgress,
+  DiffusionCalibrationReport,
 };
+
+// App-specific: calibration IPC outcome — the full report, or partial runs when
+// the sweep was cancelled (main converts CALIBRATION_ABORTED into this shape)
+export type CalibrationOutcome =
+  | DiffusionCalibrationReport
+  | { aborted: true; runs: CalibrationRun[] };
 
 // App-specific extension: ImageGenerationResult with imageDataUrl field
 // The library returns Buffer, but the app needs data URL for display
@@ -136,6 +152,10 @@ export interface WindowAPI {
       port?: number;
       threads?: number;
       gpuLayers?: number;
+      clipOnCpu?: boolean;
+      vaeOnCpu?: boolean;
+      offloadToCpu?: boolean;
+      diffusionFlashAttention?: boolean;
     }) => Promise<void>;
     stop: () => Promise<void>;
     status: () => Promise<DiffusionServerInfo>;
@@ -144,6 +164,13 @@ export interface WindowAPI {
     clearLogs: () => Promise<void>;
     generateImage: (config: ImageGenerationConfig, port?: number) => Promise<ImageGenerationResult>;
     cancel: () => Promise<{ cancelled: boolean }>;
+    calibrate: (config: {
+      modelId: string;
+      sizes?: CalibrationSize[];
+      steps?: number;
+      samples?: number;
+    }) => Promise<CalibrationOutcome>;
+    calibrateCancel: () => Promise<{ cancelling: boolean }>;
   };
   resources: {
     wouldNeedOffload: () => Promise<boolean>;

--- a/genai-electron-docs/image-generation.md
+++ b/genai-electron-docs/image-generation.md
@@ -291,6 +291,8 @@ Progress provides stage information with self-calibrating time estimates.
 
 System adapts time estimates based on hardware: first generation uses defaults, subsequent generations adjust to image size/steps.
 
+> Not to be confused with [Offload Calibration](#offload-calibration) below — that section is about benchmarking **offload flags**, this one is about progress-bar time estimates.
+
 **Example:**
 ```typescript
 const result = await diffusionServer.generateImage({
@@ -307,6 +309,91 @@ const result = await diffusionServer.generateImage({
 ### Available Samplers
 
 `euler_a` (default), `euler`, `heun` (slower, better quality), `dpm2`, `dpm++2s_a`, `dpm++2m` (good quality), `dpm++2mv2`, `lcm` (very fast), `er_sde`, `euler_cfg_pp`, `euler_a_cfg_pp` (CFG++ variants).
+
+---
+
+## Offload Calibration
+
+The fastest combination of the CPU-offload flags (`clipOnCpu`, `vaeOnCpu`, `offloadToCpu`, `diffusionFlashAttention`) is machine-dependent: driver behaviour, PCIe/RAM bandwidth, CPU speed, and OS all shift the optimum, and the flags interact (e.g. `offloadToCpu` looks inert alone but wins under the VRAM pressure that `clipOnCpu: false` creates; on Windows an oversubscribed GPU silently thrashes while on Linux it hard-OOMs). `calibrate()` measures instead of guessing: it runs real generations for each combo × size on the actual machine and reports the fastest working configuration.
+
+### calibrate(config)
+
+```typescript
+calibrate(config: DiffusionCalibrationConfig): Promise<DiffusionCalibrationReport>
+```
+
+Runs the sweep and returns a report. The caller persists/applies the recommendation — the library does not store it.
+
+**Config:** `modelId` (required), `sizes` (default `[{ width: 768, height: 768 }]` — pass your app's real sizes), `combos` (default: curated labeled set in `DIFFUSION_CALIBRATION_DEFAULTS`: `auto`, `clip-gpu`, `clip-gpu+offload`, `offload`, `all-resident`, `max-savings`), `steps` (default 4 — **use your real step count**, offload cost scales with steps), `cfgScale`, `sampler` (`'euler'`), `seed` (42, fixed so every combo does identical work), `prompt`, `samples` (2 timed samples per combo × size, after 1 discarded warmup per combo), `threads`/`batchSize` (match your production config), `onProgress`, `signal`.
+
+Default sweep cost: 6 combos × (1 warmup + 2 samples) = 18 generations — typically a few minutes.
+
+**Contract:**
+- The server must be **stopped** and is left stopped. `start()` throws while calibrating; `isCalibrating()` exposes the state (`getInfo().busy` may briefly read `true` while `status` stays `'stopped'` — harmless).
+- When the manager is wired for orchestration (the `diffusionServer` singleton is), a running LLM is offloaded **once** for the whole sweep and restored afterwards. Without orchestration wiring, stop the LLM yourself before calibrating.
+- Failing combos are recorded (`status: 'oom' | 'error'`) and never abort the sweep; the `max-savings` fallback combo means something usually succeeds even on very tight VRAM.
+- `recommended` is keyed `"<width>x<height>"` (e.g. `"768x768"`) and holds combos **as requested** — the winner may be the plain auto combo; what auto-detection resolved to is in the winning run's `resolved`. Ties within 5% of the fastest prefer fewer forced flags (robustness).
+
+**Example** (an app that commits to specific illustration sizes):
+
+```typescript
+const report = await diffusionServer.calibrate({
+  modelId: 'flux-2-klein',
+  sizes: [{ width: 768, height: 768 }, { width: 512, height: 1024 }], // the app's real sizes
+  steps: 4,                                                            // the app's quality preset
+  onProgress: (p) => updateBar(p.overallPercent, p.phase, p.combo?.label),
+});
+
+// Persist the per-size winner in your app's settings…
+const best = report.recommended['768x768'];
+if (best) {
+  const { label, ...flags } = best; // strip the label — it is not a server-config field
+  await settings.save('diffusion-flags-768', flags);
+  // …and pass the flags to future start() calls:
+  await diffusionServer.start({ modelId: 'flux-2-klein', port: 8081, ...flags });
+}
+```
+
+> **Note:** spread only the flag fields into `start()` — `label` is a UI/report field and `start()` rejects unknown config fields.
+
+### Calibration progress (progress-bar wiring)
+
+The same `DiffusionCalibrationProgress` payload is delivered on two channels: the `onProgress` callback and the `'calibration-progress'` event (mirrors `'binary-progress'` — use the event to forward over IPC):
+
+```typescript
+// Electron main process
+diffusionServer.on('calibration-progress', (p) => {
+  mainWindow.webContents.send('diffusion:calibration-progress', p);
+});
+```
+
+Payload: `phase` (`'preparing' | 'warmup' | 'sampling' | 'restoring-llm' | 'done'`), `comboIndex`/`comboCount` + `combo` (labeled), `sizeIndex`/`sizeCount` + `size`, `sample`/`sampleCount`, `generationPercent` (within the current generation), and a smooth, monotonic `overallPercent` (0–100). Throwing progress consumers are swallowed — they cannot abort the sweep.
+
+**First-run note:** binary provisioning (download + validation, potentially hundreds of MB) happens during the `'preparing'` phase and reports through the existing `'binary-progress'` event — subscribe to both for accurate first-run UX.
+
+### Cancelling a sweep
+
+Pass an `AbortSignal`. On abort the in-flight generation is killed and `calibrate()` rejects with a `ServerError` whose **`details.code === 'CALIBRATION_ABORTED'`** (the top-level `error.code` is the generic `'SERVER_ERROR'`) and `details.runs` = the completed partial runs.
+
+```typescript
+const controller = new AbortController();
+cancelButton.onclick = () => controller.abort();
+try {
+  await diffusionServer.calibrate({ modelId, signal: controller.signal });
+} catch (error) {
+  if (error.details?.code === 'CALIBRATION_ABORTED') {
+    console.log('Aborted; partial results:', error.details.runs);
+  } else throw error;
+}
+```
+
+### Caveats
+
+- **Calibrate with your real settings.** `offloadToCpu` overhead scales with step count and larger sizes shift the optimum (hence per-size recommendations). The default `steps: 4` suits distilled models (SDXL-Turbo, Flux Klein).
+- **Sizes must be positive multiples of 64** (sd.cpp constraint; validated up-front).
+- **SD3.5-Large:** combos forcing `clipOnCpu: true` are skipped automatically (garbled output upstream — leejet/stable-diffusion.cpp#1578) and listed in `report.skippedCombos`. Auto-detection may still resolve `clipOnCpu` on for auto combos on low-VRAM machines — prefer explicit `clipOnCpu: false` combos for this model family.
+- **Timing noise:** thermal throttling and background load perturb results; the raw per-sample totals are kept in `runs[].samplesMs`. `timeTakenMs` is the median (with `samples: 2`, the mean of both).
+- Each timed generation **includes model load** (sd.cpp reloads the model every generation — representative of real usage); the per-stage split is in `runs[].stageMs` (`loadMs`/`diffusionMs`/`decodeMs`).
 
 ---
 
@@ -373,6 +460,7 @@ DiffusionServerManager extends `EventEmitter`:
 - `'stopped'` - Server stopped
 - `'binary-log'` - Binary download/validation progress (receives `{ message, level }`)
 - `'binary-progress'` - Structured provisioning progress (receives `BinaryProgressEvent`: phase + file + throttled whole-percent download progress) — build progress UIs from this instead of parsing log messages
+- `'calibration-progress'` - Offload-calibration sweep progress (receives `DiffusionCalibrationProgress`; same payload as the `calibrate()` `onProgress` callback) — see [Offload Calibration](#offload-calibration)
 
 **Note:** DiffusionServerManager does not emit a `'crashed'` event because it does not maintain a persistent process — stable-diffusion.cpp is spawned on-demand for each generation. Generation failures are reported via the returned promise or HTTP error responses.
 

--- a/genai-electron-docs/index.md
+++ b/genai-electron-docs/index.md
@@ -57,6 +57,7 @@ genai-electron manages the runtime infrastructure for running local AI models (l
 - ✅ **Async image generation API** - HTTP endpoints with polling pattern for non-blocking generation
 - ✅ **Batch generation** - Generate multiple image variations in one request (1-5 images)
 - ✅ **Resource orchestration** - Automatic LLM offload/reload when generating images
+- ✅ **Offload calibration** - Benchmark CPU-offload flag combinations on the user's machine and pick the fastest (`diffusionServer.calibrate()`)
 - ✅ **Health monitoring** - Real-time server health checks and status tracking
 - ✅ **Structured logs** - Parse server logs into typed objects for easy filtering and display
 - ✅ **Binary management** - Automatic binary download and verification on first run

--- a/genai-electron-docs/resource-orchestration.md
+++ b/genai-electron-docs/resource-orchestration.md
@@ -250,6 +250,35 @@ console.log('LLM is back online');
 - Testing: asserting on reload behavior after async orchestration
 - Sequential workflows that need both image result and LLM availability
 
+### offloadLLM()
+
+Saves the current LLM configuration and stops the server to free resources. Used internally by `orchestrateImageGeneration()` and by `diffusionServer.calibrate()` (sweep-level offload: once for the whole calibration sweep instead of per generation).
+
+**Returns:** `Promise<void>`
+
+**Behavior:**
+- No-ops when the LLM server is not running
+- Throws `ServerError` if the LLM is running but its configuration cannot be retrieved
+- Pair with `reloadLLM()` to restore; call `waitForReload()` first if a background reload may be in flight (an LLM mid-reload reads as not-running and would be missed)
+
+```typescript
+await orchestrator.waitForReload();  // settle any background reload
+await orchestrator.offloadLLM();
+// ... run VRAM-heavy work ...
+await orchestrator.reloadLLM();
+```
+
+### reloadLLM()
+
+Restarts the LLM server from the saved state, retrying once after a short delay.
+
+**Returns:** `Promise<void>`
+
+**Behavior:**
+- No-ops when there is no saved state
+- **Never throws** — failures are logged and the saved state is kept so the caller (or user) can retry manually
+- Clears the saved state on success
+
 ---
 
 ## Example Scenarios

--- a/genai-electron-docs/troubleshooting.md
+++ b/genai-electron-docs/troubleshooting.md
@@ -47,7 +47,7 @@ await llamaServer.start({
 
 **Problem (historical):** On sd.cpp builds up to `master-504-636d3cb`, diffusion generation crashed silently (exit code `0xC0000005`) when the CUDA backend was combined with any CPU offloading flag: `--clip-on-cpu`, `--vae-on-cpu`, or `--offload-to-cpu`. genai-electron used to suppress these flags automatically on CUDA installs.
 
-**Now:** Fixed upstream; re-verified live on `master-746-2574f59` (all three flags, individually and combined). Since genai-electron v0.10.0 the flags are auto-detected identically on all backends. If low VRAM headroom now auto-enables offloading on your CUDA setup and you prefer the old behavior, set `clipOnCpu`/`vaeOnCpu`/`offloadToCpu` to `false` explicitly.
+**Now:** Fixed upstream; re-verified live on `master-746-2574f59` (all three flags, individually and combined). Since genai-electron v0.10.0 the flags are auto-detected identically on all backends. If low VRAM headroom now auto-enables offloading on your CUDA setup and you prefer the old behavior, set `clipOnCpu`/`vaeOnCpu`/`offloadToCpu` to `false` explicitly. To pick these flags systematically instead of guessing, run `diffusionServer.calibrate()` — it benchmarks the combinations on the actual machine (see [Offload Calibration](./image-generation.md#offload-calibration)).
 
 **Known upstream caveat:** SD3.5-Large conditioning is broken with `--clip-on-cpu` on any backend (leejet/stable-diffusion.cpp#1578) — force `clipOnCpu: false` for that model family if you hit it.
 

--- a/genai-electron-docs/typescript-reference.md
+++ b/genai-electron-docs/typescript-reference.md
@@ -544,6 +544,115 @@ interface ImageGenerationProgress {
 }
 ```
 
+### DiffusionOffloadCombo
+
+One offload combination to benchmark during [offload calibration](image-generation.md#offload-calibration). Omitted flags = auto-detect. `label` is for UIs/reports only — strip it before spreading a combo into `start()` config.
+
+```typescript
+interface DiffusionOffloadCombo {
+  label?: string;
+  clipOnCpu?: boolean;
+  vaeOnCpu?: boolean;
+  offloadToCpu?: boolean;
+  diffusionFlashAttention?: boolean;
+}
+```
+
+### CalibrationSize
+
+Dimensions to benchmark (positive multiples of 64).
+
+```typescript
+interface CalibrationSize {
+  width: number;
+  height: number;
+}
+```
+
+### DiffusionCalibrationConfig
+
+Configuration for `diffusionServer.calibrate()`. Prefer your app's real `sizes`/`steps` — the optimum shifts with both.
+
+```typescript
+interface DiffusionCalibrationConfig {
+  modelId: string;
+  sizes?: CalibrationSize[];          // default: [{ width: 768, height: 768 }]
+  combos?: DiffusionOffloadCombo[];   // default: DIFFUSION_CALIBRATION_DEFAULTS.combos
+  steps?: number;                     // default: 4
+  cfgScale?: number;                  // default: omitted (sd.cpp default)
+  sampler?: ImageSampler;             // default: 'euler'
+  seed?: number;                      // default: 42 (fixed → identical work per combo)
+  prompt?: string;                    // default: neutral built-in prompt
+  samples?: number;                   // default: 2 (timed samples per combo × size)
+  threads?: number;                   // passthrough (match production -t)
+  batchSize?: number;                 // passthrough (match production -b)
+  onProgress?: (progress: DiffusionCalibrationProgress) => void;
+  signal?: AbortSignal;               // abort → details.code === 'CALIBRATION_ABORTED'
+}
+```
+
+### DiffusionCalibrationProgress
+
+Delivered via the `onProgress` callback and the `'calibration-progress'` event (same payload).
+
+```typescript
+interface DiffusionCalibrationProgress {
+  phase: 'preparing' | 'warmup' | 'sampling' | 'restoring-llm' | 'done';
+  comboIndex: number;                 // 0-based, into the active (post-skip) combo list
+  comboCount: number;
+  combo?: DiffusionOffloadCombo;
+  sizeIndex: number;
+  sizeCount: number;
+  size?: CalibrationSize;
+  sample?: number;                    // 1-based, timed samples only
+  sampleCount?: number;
+  generationPercent?: number;         // 0-100 within the current generation
+  overallPercent: number;             // 0-100, smooth and monotonic across the sweep
+}
+```
+
+### CalibrationRun
+
+One benchmarked (combo, size) pair.
+
+```typescript
+interface CalibrationRun {
+  size: CalibrationSize;
+  combo: DiffusionOffloadCombo;       // as requested (omitted flags = auto)
+  resolved?: {                        // what auto-detection picked for this run
+    clipOnCpu: boolean;
+    vaeOnCpu: boolean;
+    offloadToCpu: boolean;
+    diffusionFlashAttention: boolean;
+  };
+  status: 'ok' | 'oom' | 'error';
+  timeTakenMs?: number;               // median of samplesMs; only when status === 'ok'
+  stageMs?: { loadMs?: number; diffusionMs?: number; decodeMs?: number };
+  samplesMs?: number[];               // raw totals of successful samples
+  error?: string;                     // when status !== 'ok'
+}
+```
+
+### DiffusionCalibrationReport
+
+```typescript
+interface DiffusionCalibrationReport {
+  machine: {
+    gpuType?: string;
+    gpuName?: string;
+    vramBytes?: number;
+    vramAvailableBytes?: number;
+  };
+  modelId: string;
+  steps: number;                      // methodology echo (persistence keying)
+  sampler: ImageSampler;
+  samples: number;
+  runs: CalibrationRun[];
+  recommended: Record<string, DiffusionOffloadCombo>; // keyed "<width>x<height>", e.g. "768x768"
+  skippedCombos?: { combo: DiffusionOffloadCombo; reason: string }[];
+}
+```
+
 ---
 
 ## Async Generation Types
@@ -764,6 +873,25 @@ Canonical iteration order for component roles.
 ```typescript
 const DIFFUSION_COMPONENT_ORDER: readonly DiffusionComponentRole[];
 // ['diffusion_model', 'clip_l', 'clip_g', 't5xxl', 'llm', 'llm_vision', 'vae']
+```
+
+### DIFFUSION_CALIBRATION_DEFAULTS
+
+Defaults for [offload calibration](image-generation.md#offload-calibration): the curated labeled combo set (`auto`, `clip-gpu`, `clip-gpu+offload`, `offload`, `all-resident`, `max-savings`), default sizes/steps/samples/seed/sampler/prompt, the 5% tie tolerance, the SD3.5-Large id/name pattern, and the OOM stderr patterns.
+
+```typescript
+const DIFFUSION_CALIBRATION_DEFAULTS: {
+  readonly sizes: readonly CalibrationSize[];       // [{ width: 768, height: 768 }]
+  readonly combos: readonly DiffusionOffloadCombo[];
+  readonly steps: number;                           // 4
+  readonly samples: number;                         // 2
+  readonly seed: number;                            // 42
+  readonly sampler: ImageSampler;                   // 'euler'
+  readonly prompt: string;
+  readonly tieTolerancePct: number;                 // 5
+  readonly sd35LargePattern: RegExp;
+  readonly oomPatterns: readonly RegExp[];
+};
 ```
 
 ---

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -3,7 +3,12 @@
  * @module config/defaults
  */
 
-import type { DiffusionComponentRole } from '../types/index.js';
+import type {
+  CalibrationSize,
+  DiffusionComponentRole,
+  DiffusionOffloadCombo,
+  ImageSampler,
+} from '../types/index.js';
 
 /**
  * Default ports for different server types
@@ -277,6 +282,53 @@ export const DIFFUSION_VRAM_THRESHOLDS = {
   /** Multiplier applied to model file size to estimate runtime VRAM footprint */
   modelOverheadMultiplier: 1.2,
 } as const;
+
+/**
+ * Defaults for DiffusionServerManager.calibrate() (offload-calibration sweeps).
+ *
+ * The combo set is curated — the full 2^4 flag grid is mostly dominated.
+ * Combo labels are surfaced by progress UIs and persisted recommendations.
+ */
+export const DIFFUSION_CALIBRATION_DEFAULTS: {
+  readonly sizes: readonly CalibrationSize[];
+  readonly combos: readonly DiffusionOffloadCombo[];
+  readonly steps: number;
+  readonly samples: number;
+  readonly seed: number;
+  readonly sampler: ImageSampler;
+  readonly prompt: string;
+  /** Runs within this % of the fastest prefer fewer forced flags (robustness tie-break) */
+  readonly tieTolerancePct: number;
+  /** Models matching this id/name pattern skip clipOnCpu combos (leejet/stable-diffusion.cpp#1578) */
+  readonly sd35LargePattern: RegExp;
+  /** stderr/message patterns classifying a failed generation as out-of-memory */
+  readonly oomPatterns: readonly RegExp[];
+} = {
+  sizes: [{ width: 768, height: 768 }],
+  combos: [
+    { label: 'auto' },
+    { label: 'clip-gpu', clipOnCpu: false },
+    { label: 'clip-gpu+offload', clipOnCpu: false, offloadToCpu: true },
+    { label: 'offload', offloadToCpu: true },
+    { label: 'all-resident', clipOnCpu: false, vaeOnCpu: false, offloadToCpu: false },
+    { label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true },
+  ],
+  steps: 4,
+  samples: 2,
+  seed: 42,
+  sampler: 'euler',
+  prompt: 'a photograph of a lighthouse on a rocky coast at sunset, detailed',
+  tieTolerancePct: 5,
+  sd35LargePattern: /(?:sd|stable[-_.\s]?diffusion)[-_.\s]?3[-_.\s]?5.*?large/i,
+  oomPatterns: [
+    /out of memory/i,
+    /cudaMalloc/i,
+    /CUDA error/i,
+    /ErrorOutOfDeviceMemory/i,
+    /failed to allocate/i,
+    /not enough memory/i,
+  ],
+};
 
 /**
  * Recommended quantizations by use case

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,7 @@ export {
   DIFFUSION_VRAM_THRESHOLDS,
   DIFFUSION_COMPONENT_FLAGS,
   DIFFUSION_COMPONENT_ORDER,
+  DIFFUSION_CALIBRATION_DEFAULTS,
 } from './config/defaults.js';
 
 // ============================================================================
@@ -303,6 +304,12 @@ export type {
   DiffusionServerInfo,
   GenerationStatus,
   GenerationState,
+  DiffusionOffloadCombo,
+  CalibrationSize,
+  DiffusionCalibrationConfig,
+  DiffusionCalibrationProgress,
+  CalibrationRun,
+  DiffusionCalibrationReport,
   // Utility types
   Optional,
   RequiredKeys,

--- a/src/managers/DiffusionServerManager.ts
+++ b/src/managers/DiffusionServerManager.ts
@@ -520,9 +520,12 @@ export class DiffusionServerManager extends ServerManager {
         );
       }
 
-      // Combo list (SD3.5-Large filter applied up-front so progress counts are accurate)
-      const requestedCombos =
-        config.combos && config.combos.length > 0 ? config.combos : [...defaults.combos];
+      // Combo list (SD3.5-Large filter applied up-front so progress counts are accurate).
+      // Per-sweep copies: report.runs[].combo / recommended hand these objects to the
+      // caller, so never share references with DIFFUSION_CALIBRATION_DEFAULTS.combos.
+      const requestedCombos = (
+        config.combos && config.combos.length > 0 ? config.combos : defaults.combos
+      ).map((combo) => ({ ...combo }));
       const skippedCombos: { combo: DiffusionOffloadCombo; reason: string }[] = [];
       let combos = requestedCombos;
       if (
@@ -600,14 +603,18 @@ export class DiffusionServerManager extends ServerManager {
       if (!this.logManager) {
         await this.initializeLogManager('diffusion-server.log', 'Offload calibration starting');
       }
-      await this.logManager?.write(
-        `Calibration: model=${config.modelId}, sizes=${sizes
-          .map((s) => `${s.width}x${s.height}`)
-          .join(',')}, combos=${combos.length}${
-          skippedCombos.length > 0 ? ` (${skippedCombos.length} skipped: SD3.5-Large)` : ''
-        }, steps=${steps}, samples=${samples}`,
-        'info'
-      );
+      // Fire-and-forget (matching executeImageGeneration): a log-write failure
+      // must never abort a sweep this expensive
+      void this.logManager
+        ?.write(
+          `Calibration: model=${config.modelId}, sizes=${sizes
+            .map((s) => `${s.width}x${s.height}`)
+            .join(',')}, combos=${combos.length}${
+            skippedCombos.length > 0 ? ` (${skippedCombos.length} skipped: SD3.5-Large)` : ''
+          }, steps=${steps}, samples=${samples}`,
+          'info'
+        )
+        .catch(() => void 0);
 
       // Install working state. May download the binary on first run
       // (long; reports via 'binary-progress'/'binary-log' events).
@@ -779,12 +786,14 @@ export class DiffusionServerManager extends ServerManager {
             }
           }
           runs.push(run);
-          await this.logManager?.write(
-            `Calibration run: ${combo.label ?? JSON.stringify(combo)} @ ${size.width}x${size.height} → ${run.status}${
-              run.timeTakenMs !== undefined ? ` (${Math.round(run.timeTakenMs)} ms)` : ''
-            }${run.error ? ` — ${run.error.split('\n')[0]}` : ''}`,
-            run.status === 'ok' ? 'info' : 'warn'
-          );
+          void this.logManager
+            ?.write(
+              `Calibration run: ${combo.label ?? JSON.stringify(combo)} @ ${size.width}x${size.height} → ${run.status}${
+                run.timeTakenMs !== undefined ? ` (${Math.round(run.timeTakenMs)} ms)` : ''
+              }${run.error ? ` — ${run.error.split('\n')[0]}` : ''}`,
+              run.status === 'ok' ? 'info' : 'warn'
+            )
+            .catch(() => void 0);
         }
       }
 
@@ -825,6 +834,11 @@ export class DiffusionServerManager extends ServerManager {
       this.currentModelInfo = savedModelInfo;
       this.binaryPath = savedBinaryPath;
 
+      // Release the manager before the awaited LLM reload: reloadLLM() is
+      // contractually never-throwing, but if that ever regressed a throw here
+      // must not leave the manager permanently locked in calibrating state
+      this.calibrating = false;
+
       if (this.orchestrator) {
         emitFn?.({
           phase: 'restoring-llm',
@@ -847,8 +861,6 @@ export class DiffusionServerManager extends ServerManager {
           overallPercent: 100,
         });
       }
-
-      this.calibrating = false;
     }
   }
 

--- a/src/managers/DiffusionServerManager.ts
+++ b/src/managers/DiffusionServerManager.ts
@@ -24,15 +24,29 @@ import {
   DIFFUSION_VRAM_THRESHOLDS,
   DIFFUSION_COMPONENT_FLAGS,
   DIFFUSION_COMPONENT_ORDER,
+  DIFFUSION_CALIBRATION_DEFAULTS,
 } from '../config/defaults.js';
 import { deleteFile } from '../utils/file-utils.js';
+import { debugLog } from '../utils/debug-log.js';
 import { findFreePort } from '../process/port-utils.js';
-import { ServerError, ModelNotFoundError, InsufficientResourcesError } from '../errors/index.js';
+import {
+  GenaiElectronError,
+  ServerError,
+  ModelNotFoundError,
+  InsufficientResourcesError,
+} from '../errors/index.js';
 import type {
+  CalibrationRun,
+  CalibrationSize,
+  DiffusionCalibrationConfig,
+  DiffusionCalibrationProgress,
+  DiffusionCalibrationReport,
+  DiffusionOffloadCombo,
   DiffusionServerConfig,
   DiffusionServerInfo,
   ImageGenerationConfig,
   ImageGenerationResult,
+  ImageSampler,
   ModelInfo,
   ServerInfo,
 } from '../types/index.js';
@@ -105,6 +119,18 @@ export class DiffusionServerManager extends ServerManager {
    */
   private activeGeneration?: { id: string; cancelled: boolean };
   private currentModelInfo?: ModelInfo;
+  /**
+   * Flags resolved by the most recent computeDiffusionOptimizations() call.
+   * Read by calibrate() after each run to report what auto-detection picked.
+   */
+  private lastResolvedOptimizations?: {
+    clipOnCpu: boolean;
+    vaeOnCpu: boolean;
+    offloadToCpu: boolean;
+    diffusionFlashAttention: boolean;
+  };
+  /** True while an offload-calibration sweep is running (server stays 'stopped') */
+  private calibrating = false;
 
   // Time estimates for progress calculation (self-calibrating)
   private modelLoadTime = 2000; // Fixed cost in ms
@@ -180,6 +206,12 @@ export class DiffusionServerManager extends ServerManager {
     if (this._status === 'running') {
       throw new ServerError('Server is already running', {
         suggestion: 'Stop the server first with stop()',
+      });
+    }
+
+    if (this.calibrating) {
+      throw new ServerError('Cannot start server while offload calibration is in progress', {
+        suggestion: 'Wait for calibrate() to finish, or abort it via its AbortSignal',
       });
     }
 
@@ -378,6 +410,544 @@ export class DiffusionServerManager extends ServerManager {
     }
 
     await this.logManager?.write(`Generation ${id} cancelled`, 'info');
+  }
+
+  /**
+   * Benchmark CPU-offload flag combinations on this machine (offload calibration)
+   *
+   * Runs a sweep of real generations across the given sizes × combos and returns
+   * a report with per-run timings, per-stage splits, OOM/error classification,
+   * and the fastest working combo per size. The optimum depends on the whole
+   * system (driver behaviour, PCIe/RAM bandwidth, CPU speed, OS) and the flags
+   * interact — measuring on the target machine is the only reliable way to pick.
+   *
+   * Contract:
+   * - The server must be STOPPED and is left stopped afterwards; start() throws
+   *   while a calibration is in flight.
+   * - When constructed with a llamaServer, a running LLM is offloaded once for
+   *   the whole sweep and restored afterwards. Otherwise stop the LLM yourself
+   *   before calibrating.
+   * - Combos that fail are recorded ('oom'/'error') and never abort the sweep.
+   * - Progress is delivered via config.onProgress and 'calibration-progress'
+   *   events (same payload); first-run binary provisioning happens during the
+   *   'preparing' phase and reports via 'binary-progress'.
+   * - Aborting via config.signal rejects with a ServerError whose
+   *   details.code === 'CALIBRATION_ABORTED' and details.runs = partial runs.
+   *
+   * @param config - Calibration configuration (modelId required)
+   * @returns Calibration report — the caller persists/applies the recommendation
+   * @throws {ServerError} If the server is running, a calibration is already in
+   *   flight, sizes are invalid, or the sweep is aborted
+   * @throws {ModelNotFoundError} If the model doesn't exist or is not a diffusion model
+   * @throws {InsufficientResourcesError} If the system cannot run the model
+   *
+   * @example
+   * ```typescript
+   * const report = await diffusionServer.calibrate({
+   *   modelId: 'flux-2-klein',
+   *   sizes: [{ width: 768, height: 768 }],
+   *   steps: 4, // your app's real step count
+   *   onProgress: (p) => console.log(`${p.phase} ${Math.round(p.overallPercent)}%`),
+   * });
+   * const best = report.recommended['768x768'];
+   * // Persist `best` and pass its flags to future start() calls
+   * ```
+   */
+  async calibrate(config: DiffusionCalibrationConfig): Promise<DiffusionCalibrationReport> {
+    if (this._status !== 'stopped') {
+      throw new ServerError('Cannot calibrate while the server is running', {
+        suggestion: 'Stop the server with stop() before calibrating',
+      });
+    }
+    if (this.calibrating) {
+      throw new ServerError('Calibration is already in progress', {
+        suggestion: 'Wait for the current calibrate() call to finish',
+      });
+    }
+
+    const defaults = DIFFUSION_CALIBRATION_DEFAULTS;
+    const sizes = config.sizes && config.sizes.length > 0 ? config.sizes : [...defaults.sizes];
+    for (const size of sizes) {
+      if (
+        !Number.isInteger(size.width) ||
+        !Number.isInteger(size.height) ||
+        size.width <= 0 ||
+        size.height <= 0 ||
+        size.width % 64 !== 0 ||
+        size.height % 64 !== 0
+      ) {
+        throw new ServerError(
+          `Invalid calibration size ${size.width}x${size.height}: dimensions must be positive multiples of 64`,
+          { suggestion: 'Use sd.cpp-compatible dimensions, e.g. 512x512, 768x768, 512x1024' }
+        );
+      }
+    }
+    const samples = Math.max(1, Math.floor(config.samples ?? defaults.samples));
+    const steps = config.steps ?? defaults.steps;
+    const seed = config.seed ?? defaults.seed;
+    const sampler = config.sampler ?? defaults.sampler;
+    const prompt = config.prompt ?? defaults.prompt;
+
+    const runs: CalibrationRun[] = [];
+    if (config.signal?.aborted) {
+      throw this.calibrationAbortError(runs);
+    }
+
+    this.calibrating = true;
+
+    // Instance state executeImageGeneration depends on — restored in finally
+    const savedConfig = this._config;
+    const savedModelInfo = this.currentModelInfo;
+    const savedBinaryPath = this.binaryPath;
+
+    const abortListener = (): void => {
+      this.currentGeneration?.cancel();
+    };
+    config.signal?.addEventListener('abort', abortListener);
+
+    // Hoisted for the finally block ('restoring-llm'/'done' emits)
+    let emitFn: ((p: DiffusionCalibrationProgress) => void) | undefined;
+    let comboCountForProgress = 0;
+    let lastOverallPercent = 0;
+    let succeeded = false;
+
+    try {
+      // --- Setup (phase 'preparing') ---
+      const modelInfo = await this.modelManager.getModelInfo(config.modelId);
+      if (modelInfo.type !== 'diffusion') {
+        throw new ModelNotFoundError(
+          `Model ${config.modelId} is not a diffusion model (type: ${modelInfo.type})`
+        );
+      }
+
+      // Combo list (SD3.5-Large filter applied up-front so progress counts are accurate)
+      const requestedCombos =
+        config.combos && config.combos.length > 0 ? config.combos : [...defaults.combos];
+      const skippedCombos: { combo: DiffusionOffloadCombo; reason: string }[] = [];
+      let combos = requestedCombos;
+      if (
+        defaults.sd35LargePattern.test(modelInfo.id) ||
+        defaults.sd35LargePattern.test(modelInfo.name)
+      ) {
+        combos = requestedCombos.filter((combo) => {
+          if (combo.clipOnCpu === true) {
+            skippedCombos.push({
+              combo,
+              reason:
+                'SD3.5-Large produces garbled output with --clip-on-cpu (leejet/stable-diffusion.cpp#1578)',
+            });
+            return false;
+          }
+          return true;
+        });
+      }
+      if (combos.length === 0) {
+        throw new ServerError('No offload combos left to benchmark after SD3.5-Large filtering', {
+          skippedCombos,
+          suggestion: 'Provide combos without clipOnCpu: true for this model',
+        });
+      }
+      comboCountForProgress = combos.length;
+
+      // Progress plumbing: units = every generation in the sweep (warmups included).
+      // Units skipped by failure handling are counted as completed so the bar
+      // still reaches 100 by folding (no stall-then-jump).
+      const totalUnits = combos.length * (1 + samples * sizes.length);
+      let completedUnits = 0;
+      const emit = (p: DiffusionCalibrationProgress): void => {
+        try {
+          config.onProgress?.(p);
+        } catch (error) {
+          debugLog('[Calibrate] onProgress callback threw:', error);
+        }
+        try {
+          this.emit('calibration-progress', p);
+        } catch (error) {
+          debugLog('[Calibrate] calibration-progress listener threw:', error);
+        }
+      };
+      emitFn = emit;
+      const overallPercent = (generationFraction = 0): number => {
+        const pct = Math.min(100, ((completedUnits + generationFraction) / totalUnits) * 100);
+        // Clamp monotonic: per-generation estimates can dip when their
+        // denominator re-calibrates mid-generation
+        lastOverallPercent = Math.max(lastOverallPercent, pct);
+        return lastOverallPercent;
+      };
+
+      emit({
+        phase: 'preparing',
+        comboIndex: 0,
+        comboCount: combos.length,
+        sizeIndex: 0,
+        sizeCount: sizes.length,
+        overallPercent: 0,
+      });
+
+      const canRun = await this.systemInfo.canRunModel(modelInfo, { checkTotalMemory: true });
+      if (!canRun.possible) {
+        const memoryInfo = this.systemInfo.getMemoryInfo();
+        throw new InsufficientResourcesError(
+          `System cannot run model: ${canRun.reason || 'Insufficient resources'}`,
+          {
+            required: `Model size: ${Math.round(modelInfo.size / 1024 / 1024 / 1024)}GB`,
+            available: `Total RAM: ${Math.round(memoryInfo.total / 1024 / 1024 / 1024)}GB`,
+            suggestion: canRun.suggestion || canRun.reason || 'Try a smaller model',
+          }
+        );
+      }
+
+      if (!this.logManager) {
+        await this.initializeLogManager('diffusion-server.log', 'Offload calibration starting');
+      }
+      await this.logManager?.write(
+        `Calibration: model=${config.modelId}, sizes=${sizes
+          .map((s) => `${s.width}x${s.height}`)
+          .join(',')}, combos=${combos.length}${
+          skippedCombos.length > 0 ? ` (${skippedCombos.length} skipped: SD3.5-Large)` : ''
+        }, steps=${steps}, samples=${samples}`,
+        'info'
+      );
+
+      // Install working state. May download the binary on first run
+      // (long; reports via 'binary-progress'/'binary-log' events).
+      this.currentModelInfo = modelInfo;
+      this.binaryPath = await this.ensureBinary(modelInfo);
+      if (config.signal?.aborted) {
+        throw this.calibrationAbortError(runs);
+      }
+      const syntheticConfig: DiffusionServerConfig = { modelId: config.modelId };
+      if (config.threads !== undefined) {
+        syntheticConfig.threads = config.threads;
+      }
+      if (config.batchSize !== undefined) {
+        syntheticConfig.batchSize = config.batchSize;
+      }
+      this._config = syntheticConfig as unknown as typeof this._config;
+
+      // Offload a running LLM once for the whole sweep (measurement hygiene).
+      // waitForReload() first: a background reload from a prior orchestrated
+      // generation would otherwise read as not-running and come back mid-sweep.
+      await this.orchestrator?.waitForReload();
+      await this.orchestrator?.offloadLLM();
+
+      // --- Sweep (combo-outer, size-inner; every generation does identical work) ---
+      for (let comboIndex = 0; comboIndex < combos.length; comboIndex++) {
+        const combo = combos[comboIndex]!;
+        const baseProgress = {
+          comboIndex,
+          comboCount: combos.length,
+          combo,
+          sizeCount: sizes.length,
+        };
+
+        // Warmup at the first size (discarded; stabilizes disk cache / first-spawn overhead)
+        let warmupFailure: { status: 'oom' | 'error'; message: string } | undefined;
+        if (config.signal?.aborted) {
+          throw this.calibrationAbortError(runs);
+        }
+        emit({
+          phase: 'warmup',
+          ...baseProgress,
+          sizeIndex: 0,
+          size: sizes[0]!,
+          overallPercent: overallPercent(),
+        });
+        try {
+          await this.runCalibrationGeneration({
+            prompt,
+            size: sizes[0]!,
+            steps,
+            cfgScale: config.cfgScale,
+            seed,
+            sampler,
+            combo,
+            onGenerationProgress: (pct) =>
+              emit({
+                phase: 'warmup',
+                ...baseProgress,
+                sizeIndex: 0,
+                size: sizes[0]!,
+                generationPercent: pct,
+                overallPercent: overallPercent(pct / 100),
+              }),
+          });
+        } catch (error) {
+          if (config.signal?.aborted) {
+            throw this.calibrationAbortError(runs);
+          }
+          warmupFailure = this.classifyCalibrationFailure(error);
+        }
+        completedUnits++;
+
+        for (let sizeIndex = 0; sizeIndex < sizes.length; sizeIndex++) {
+          const size = sizes[sizeIndex]!;
+          const samplesMs: number[] = [];
+          const snapshots: { loadMs?: number; diffusionMs?: number; decodeMs?: number }[] = [];
+          let resolved: CalibrationRun['resolved'];
+          let failure: { status: 'oom' | 'error'; message: string } | undefined;
+
+          if (sizeIndex === 0 && warmupFailure) {
+            // Warmup already failed at this size — skip its timed samples.
+            // Later sizes are still attempted (failure at one size doesn't
+            // imply failure at another).
+            failure = warmupFailure;
+            completedUnits += samples;
+          } else {
+            for (let sample = 1; sample <= samples; sample++) {
+              if (config.signal?.aborted) {
+                throw this.calibrationAbortError(runs);
+              }
+              emit({
+                phase: 'sampling',
+                ...baseProgress,
+                sizeIndex,
+                size,
+                sample,
+                sampleCount: samples,
+                overallPercent: overallPercent(),
+              });
+              try {
+                const result = await this.runCalibrationGeneration({
+                  prompt,
+                  size,
+                  steps,
+                  cfgScale: config.cfgScale,
+                  seed,
+                  sampler,
+                  combo,
+                  onGenerationProgress: (pct) =>
+                    emit({
+                      phase: 'sampling',
+                      ...baseProgress,
+                      sizeIndex,
+                      size,
+                      sample,
+                      sampleCount: samples,
+                      generationPercent: pct,
+                      overallPercent: overallPercent(pct / 100),
+                    }),
+                });
+                samplesMs.push(result.timeTaken);
+                // Snapshot per sample: the stage timestamps are instance
+                // fields reset by the next generation
+                snapshots.push(this.snapshotStageMs());
+                resolved = this.lastResolvedOptimizations
+                  ? { ...this.lastResolvedOptimizations }
+                  : undefined;
+                completedUnits++;
+              } catch (error) {
+                if (config.signal?.aborted) {
+                  throw this.calibrationAbortError(runs);
+                }
+                failure = this.classifyCalibrationFailure(error);
+                // Failed sample + skipped remainder count as completed units
+                completedUnits += samples - sample + 1;
+                break;
+              }
+            }
+          }
+
+          // Bookkeeping invariant: exactly one CalibrationRun per (combo, size)
+          const run: CalibrationRun = { size, combo, status: failure ? failure.status : 'ok' };
+          if (resolved) {
+            run.resolved = resolved;
+          }
+          if (samplesMs.length > 0) {
+            run.samplesMs = samplesMs;
+          }
+          if (failure) {
+            run.error = failure.message;
+          } else {
+            const median = medianOf(samplesMs);
+            run.timeTakenMs = median;
+            // Stage split of the sample whose total is closest to the median
+            let bestIdx = 0;
+            for (let i = 1; i < samplesMs.length; i++) {
+              if (Math.abs(samplesMs[i]! - median) < Math.abs(samplesMs[bestIdx]! - median)) {
+                bestIdx = i;
+              }
+            }
+            const stage = snapshots[bestIdx];
+            if (
+              stage &&
+              (stage.loadMs !== undefined ||
+                stage.diffusionMs !== undefined ||
+                stage.decodeMs !== undefined)
+            ) {
+              run.stageMs = stage;
+            }
+          }
+          runs.push(run);
+          await this.logManager?.write(
+            `Calibration run: ${combo.label ?? JSON.stringify(combo)} @ ${size.width}x${size.height} → ${run.status}${
+              run.timeTakenMs !== undefined ? ` (${Math.round(run.timeTakenMs)} ms)` : ''
+            }${run.error ? ` — ${run.error.split('\n')[0]}` : ''}`,
+            run.status === 'ok' ? 'info' : 'warn'
+          );
+        }
+      }
+
+      // --- Report ---
+      const recommended = pickRecommended(runs, defaults.tieTolerancePct);
+
+      const machine: DiffusionCalibrationReport['machine'] = {};
+      try {
+        const gpu = await this.systemInfo.getGPUInfo();
+        machine.gpuType = gpu.type;
+        machine.gpuName = gpu.name;
+        machine.vramBytes = gpu.vram;
+        machine.vramAvailableBytes = gpu.vramAvailable;
+      } catch {
+        // GPU info unavailable — leave the machine fingerprint empty
+      }
+
+      const report: DiffusionCalibrationReport = {
+        machine,
+        modelId: config.modelId,
+        steps,
+        sampler,
+        samples,
+        runs,
+        recommended,
+      };
+      if (skippedCombos.length > 0) {
+        report.skippedCombos = skippedCombos;
+      }
+
+      succeeded = true;
+      return report;
+    } finally {
+      config.signal?.removeEventListener('abort', abortListener);
+
+      // Restore instance state (server remains stopped)
+      this._config = savedConfig;
+      this.currentModelInfo = savedModelInfo;
+      this.binaryPath = savedBinaryPath;
+
+      if (this.orchestrator) {
+        emitFn?.({
+          phase: 'restoring-llm',
+          comboIndex: Math.max(0, comboCountForProgress - 1),
+          comboCount: comboCountForProgress,
+          sizeIndex: Math.max(0, sizes.length - 1),
+          sizeCount: sizes.length,
+          overallPercent: succeeded ? 100 : lastOverallPercent,
+        });
+        await this.orchestrator.reloadLLM();
+      }
+
+      if (succeeded) {
+        emitFn?.({
+          phase: 'done',
+          comboIndex: Math.max(0, comboCountForProgress - 1),
+          comboCount: comboCountForProgress,
+          sizeIndex: Math.max(0, sizes.length - 1),
+          sizeCount: sizes.length,
+          overallPercent: 100,
+        });
+      }
+
+      this.calibrating = false;
+    }
+  }
+
+  /**
+   * Check if an offload-calibration sweep is currently running
+   *
+   * The server status stays 'stopped' during calibration; this is the
+   * dedicated signal for calibration exclusivity.
+   *
+   * @returns True while calibrate() is in flight
+   */
+  isCalibrating(): boolean {
+    return this.calibrating;
+  }
+
+  /**
+   * Build the standard calibration-abort error
+   * (top-level code is 'SERVER_ERROR'; discriminate via details.code)
+   * @private
+   */
+  private calibrationAbortError(runs: CalibrationRun[]): ServerError {
+    return new ServerError('Calibration aborted', {
+      code: 'CALIBRATION_ABORTED',
+      runs: [...runs],
+      suggestion: 'Partial results are available in error.details.runs',
+    });
+  }
+
+  /**
+   * Run one calibration generation with per-combo flag overrides
+   * @private
+   */
+  private async runCalibrationGeneration(params: {
+    prompt: string;
+    size: CalibrationSize;
+    steps: number;
+    cfgScale?: number;
+    seed: number;
+    sampler: ImageSampler;
+    combo: DiffusionOffloadCombo;
+    onGenerationProgress: (percentage: number) => void;
+  }): Promise<ImageGenerationResult> {
+    const genConfig: ImageGenerationConfig = {
+      prompt: params.prompt,
+      width: params.size.width,
+      height: params.size.height,
+      steps: params.steps,
+      seed: params.seed,
+      sampler: params.sampler,
+      onProgress: (_currentStep, _totalSteps, _stage, percentage) => {
+        if (percentage !== undefined) {
+          params.onGenerationProgress(percentage);
+        }
+      },
+    };
+    if (params.cfgScale !== undefined) {
+      genConfig.cfgScale = params.cfgScale;
+    }
+    return this.executeImageGeneration(genConfig, params.combo);
+  }
+
+  /**
+   * Snapshot per-stage durations from the last generation's timestamps
+   * @private
+   */
+  private snapshotStageMs(): { loadMs?: number; diffusionMs?: number; decodeMs?: number } {
+    const stage: { loadMs?: number; diffusionMs?: number; decodeMs?: number } = {};
+    if (this.loadStartTime && this.loadEndTime) {
+      stage.loadMs = this.loadEndTime - this.loadStartTime;
+    }
+    if (this.diffusionStartTime && this.diffusionEndTime) {
+      stage.diffusionMs = this.diffusionEndTime - this.diffusionStartTime;
+    }
+    if (this.vaeStartTime && this.vaeEndTime) {
+      stage.decodeMs = this.vaeEndTime - this.vaeStartTime;
+    }
+    return stage;
+  }
+
+  /**
+   * Classify a failed calibration generation as OOM or generic error
+   * (from the error message + captured stderr)
+   * @private
+   */
+  private classifyCalibrationFailure(error: unknown): {
+    status: 'oom' | 'error';
+    message: string;
+  } {
+    const message = error instanceof Error ? error.message : String(error);
+    let stderr = '';
+    if (error instanceof GenaiElectronError && error.details && typeof error.details === 'object') {
+      const detailStderr = (error.details as Record<string, unknown>).stderr;
+      if (typeof detailStderr === 'string') {
+        stderr = detailStderr;
+      }
+    }
+    const text = `${message}\n${stderr}`;
+    const isOom = DIFFUSION_CALIBRATION_DEFAULTS.oomPatterns.some((pattern) => pattern.test(text));
+    return { status: isOom ? 'oom' : 'error', message };
   }
 
   /**
@@ -815,11 +1385,14 @@ export class DiffusionServerManager extends ServerManager {
    * External callers should use generateImage() which includes automatic resource management.
    *
    * @param config - Image generation configuration
+   * @param flagOverrides - Per-generation offload-flag overrides (used by calibrate();
+   *   takes precedence over server config and auto-detection)
    * @returns Generated image result
    * @internal
    */
   public async executeImageGeneration(
-    config: ImageGenerationConfig
+    config: ImageGenerationConfig,
+    flagOverrides?: DiffusionOffloadCombo
   ): Promise<ImageGenerationResult> {
     const startTime = Date.now();
 
@@ -839,7 +1412,7 @@ export class DiffusionServerManager extends ServerManager {
     this.initializeProgressTracking(normalizedConfig);
 
     // Compute VRAM optimizations (fresh GPU info, respects user overrides)
-    const optimizations = await this.computeDiffusionOptimizations();
+    const optimizations = await this.computeDiffusionOptimizations(flagOverrides);
 
     // Build command-line arguments
     const args = this.buildDiffusionArgs(normalizedConfig, this.currentModelInfo, optimizations);
@@ -1021,12 +1594,14 @@ export class DiffusionServerManager extends ServerManager {
    * VRAM landscape — the orchestrator may have offloaded the LLM between start()
    * and generation.
    *
-   * User-provided overrides in DiffusionServerConfig always win via nullish coalescing.
+   * Precedence per flag: flagOverrides (per-generation, used by calibrate())
+   * → DiffusionServerConfig (user start-config) → auto-detection.
    *
+   * @param flagOverrides - Optional per-generation offload-flag overrides
    * @returns Resolved optimization flags: clipOnCpu, vaeOnCpu, batchSize
    * @private
    */
-  private async computeDiffusionOptimizations(): Promise<{
+  private async computeDiffusionOptimizations(flagOverrides?: DiffusionOffloadCombo): Promise<{
     clipOnCpu: boolean;
     vaeOnCpu: boolean;
     offloadToCpu: boolean;
@@ -1075,12 +1650,17 @@ export class DiffusionServerManager extends ServerManager {
     const hasLLMComponent = !!this.currentModelInfo?.components?.llm;
     const autoDiffusionFlashAttention = hasLLMComponent;
 
-    const clipOnCpu = serverConfig.clipOnCpu ?? autoClipOnCpu;
-    const vaeOnCpu = serverConfig.vaeOnCpu ?? autoVaeOnCpu;
-    const offloadToCpu = serverConfig.offloadToCpu ?? autoOffloadToCpu;
+    const clipOnCpu = flagOverrides?.clipOnCpu ?? serverConfig.clipOnCpu ?? autoClipOnCpu;
+    const vaeOnCpu = flagOverrides?.vaeOnCpu ?? serverConfig.vaeOnCpu ?? autoVaeOnCpu;
+    const offloadToCpu =
+      flagOverrides?.offloadToCpu ?? serverConfig.offloadToCpu ?? autoOffloadToCpu;
     const diffusionFlashAttention =
-      serverConfig.diffusionFlashAttention ?? autoDiffusionFlashAttention;
+      flagOverrides?.diffusionFlashAttention ??
+      serverConfig.diffusionFlashAttention ??
+      autoDiffusionFlashAttention;
     const batchSize = serverConfig.batchSize;
+
+    this.lastResolvedOptimizations = { clipOnCpu, vaeOnCpu, offloadToCpu, diffusionFlashAttention };
 
     await this.logManager?.write(
       `VRAM optimizations: clipOnCpu=${clipOnCpu}, vaeOnCpu=${vaeOnCpu}, offloadToCpu=${offloadToCpu}, diffusionFa=${diffusionFlashAttention}${batchSize !== undefined ? `, batchSize=${batchSize}` : ''} (auto: clip=${autoClipOnCpu}, vae=${autoVaeOnCpu}, offload=${autoOffloadToCpu}, fa=${autoDiffusionFlashAttention})`,
@@ -1522,4 +2102,71 @@ export class DiffusionServerManager extends ServerManager {
       this.vaeTimePerMegapixel = inferredTime / megapixels;
     }
   }
+}
+
+/**
+ * Median of a non-empty numeric array (mean of the middle two for even counts)
+ * @internal
+ */
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+/**
+ * Number of explicitly forced flags in a combo (label excluded)
+ * @internal
+ */
+function countForcedFlags(combo: DiffusionOffloadCombo): number {
+  let count = 0;
+  if (combo.clipOnCpu !== undefined) count++;
+  if (combo.vaeOnCpu !== undefined) count++;
+  if (combo.offloadToCpu !== undefined) count++;
+  if (combo.diffusionFlashAttention !== undefined) count++;
+  return count;
+}
+
+/**
+ * Pick the recommended offload combo per size from calibration runs.
+ *
+ * Per size: the fastest run with status 'ok' wins; any OK run within
+ * `tolerancePct` percent of the fastest that forces FEWER flags wins the tie
+ * (robustness preference — closer to auto). Sizes where every combo failed
+ * are absent from the result.
+ *
+ * Exported for direct unit testing; not part of the public package API.
+ * @internal
+ */
+export function pickRecommended(
+  runs: CalibrationRun[],
+  tolerancePct: number
+): Record<string, DiffusionOffloadCombo> {
+  const bySize = new Map<string, CalibrationRun[]>();
+  for (const run of runs) {
+    if (run.status !== 'ok' || run.timeTakenMs === undefined) {
+      continue;
+    }
+    const key = `${run.size.width}x${run.size.height}`;
+    const list = bySize.get(key);
+    if (list) {
+      list.push(run);
+    } else {
+      bySize.set(key, [run]);
+    }
+  }
+
+  const recommended: Record<string, DiffusionOffloadCombo> = {};
+  for (const [key, okRuns] of bySize) {
+    const fastest = okRuns.reduce((a, b) => (b.timeTakenMs! < a.timeTakenMs! ? b : a));
+    const threshold = fastest.timeTakenMs! * (1 + tolerancePct / 100);
+    const winner = okRuns
+      .filter((run) => run.timeTakenMs! <= threshold)
+      .sort(
+        (a, b) =>
+          countForcedFlags(a.combo) - countForcedFlags(b.combo) || a.timeTakenMs! - b.timeTakenMs!
+      )[0]!;
+    recommended[key] = winner.combo;
+  }
+  return recommended;
 }

--- a/src/managers/ResourceOrchestrator.ts
+++ b/src/managers/ResourceOrchestrator.ts
@@ -362,14 +362,24 @@ export class ResourceOrchestrator {
   }
 
   /**
-   * Offload LLM (save state and stop)
+   * Offload the LLM (save state and stop)
    *
    * Saves the current LLM configuration and stops the server to free resources.
+   * Used internally by orchestrateImageGeneration() and by
+   * DiffusionServerManager.calibrate() for sweep-level offload.
    *
-   * @throws {ServerError} If no configuration found
-   * @private
+   * No-ops when the LLM server is not running.
+   *
+   * @throws {ServerError} If the LLM is running but its configuration cannot be retrieved
+   *
+   * @example
+   * ```typescript
+   * await orchestrator.offloadLLM();
+   * // ... run VRAM-heavy work ...
+   * await orchestrator.reloadLLM();
+   * ```
    */
-  private async offloadLLM(): Promise<void> {
+  async offloadLLM(): Promise<void> {
     debugLog('[Orchestrator] offloadLLM called');
 
     if (!this.llamaServer.isRunning()) {
@@ -402,14 +412,15 @@ export class ResourceOrchestrator {
   }
 
   /**
-   * Reload LLM (restore from saved state)
+   * Reload the LLM (restore from saved state)
    *
-   * Restarts the LLM server with the previously saved configuration.
-   * Errors are logged but not thrown to avoid disrupting image generation.
+   * Restarts the LLM server with the previously saved configuration, retrying
+   * once after a short delay. No-ops when there is no saved state.
    *
-   * @private
+   * Never throws — errors are logged and the saved state is kept so the
+   * caller (or user) can retry manually.
    */
-  private async reloadLLM(): Promise<void> {
+  async reloadLLM(): Promise<void> {
     debugLog('[Orchestrator] reloadLLM called');
 
     if (!this.savedLLMState || !this.savedLLMState.wasRunning) {

--- a/src/types/images.ts
+++ b/src/types/images.ts
@@ -270,3 +270,202 @@ export interface GenerationState {
     code: string;
   };
 }
+
+/**
+ * One offload combination to benchmark during offload calibration.
+ *
+ * Omitted flags are auto-detected, exactly as when they are omitted in
+ * DiffusionServerConfig.
+ */
+export interface DiffusionOffloadCombo {
+  /** Human-readable label for progress UIs and reports (ignored by flag resolution) */
+  label?: string;
+
+  /** Force CLIP/text-encoder placement (--clip-on-cpu). Omitted = auto-detect */
+  clipOnCpu?: boolean;
+
+  /** Force VAE decoder placement (--vae-on-cpu). Omitted = auto-detect */
+  vaeOnCpu?: boolean;
+
+  /** Force managed weight streaming (--offload-to-cpu). Omitted = auto-detect */
+  offloadToCpu?: boolean;
+
+  /** Force diffusion flash attention (--diffusion-fa). Omitted = auto-detect */
+  diffusionFlashAttention?: boolean;
+}
+
+/**
+ * Image dimensions to benchmark during offload calibration
+ */
+export interface CalibrationSize {
+  /** Image width in pixels (must be a positive multiple of 64) */
+  width: number;
+
+  /** Image height in pixels (must be a positive multiple of 64) */
+  height: number;
+}
+
+/**
+ * Configuration for DiffusionServerManager.calibrate()
+ */
+export interface DiffusionCalibrationConfig {
+  /** Diffusion model ID to calibrate */
+  modelId: string;
+
+  /** Sizes to benchmark (default: [{ width: 768, height: 768 }]). Pass your app's real sizes */
+  sizes?: CalibrationSize[];
+
+  /** Offload combos to benchmark (default: curated set in DIFFUSION_CALIBRATION_DEFAULTS) */
+  combos?: DiffusionOffloadCombo[];
+
+  /**
+   * Inference steps per generation (default: 4).
+   * Offload cost scales with steps — prefer your app's real step count.
+   */
+  steps?: number;
+
+  /** Guidance scale (default: omitted, uses the sd.cpp default) */
+  cfgScale?: number;
+
+  /** Sampler algorithm (default: 'euler') */
+  sampler?: ImageSampler;
+
+  /** Fixed seed so every combo does identical work (default: 42) */
+  seed?: number;
+
+  /** Benchmark prompt (default: neutral built-in prompt) */
+  prompt?: string;
+
+  /** Timed samples per (combo, size), after 1 discarded warmup per combo (default: 2) */
+  samples?: number;
+
+  /** CPU threads passthrough — match your production config (default: omitted) */
+  threads?: number;
+
+  /** Batch size passthrough — match your production config (default: omitted) */
+  batchSize?: number;
+
+  /** Progress callback (the same payload is also emitted as 'calibration-progress' events) */
+  onProgress?: (progress: DiffusionCalibrationProgress) => void;
+
+  /**
+   * Abort the sweep. calibrate() then rejects with a ServerError whose
+   * details.code === 'CALIBRATION_ABORTED' and details.runs = partial runs.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Progress payload for an offload-calibration sweep
+ * (delivered via onProgress and the 'calibration-progress' event)
+ */
+export interface DiffusionCalibrationProgress {
+  /** Sweep phase */
+  phase: 'preparing' | 'warmup' | 'sampling' | 'restoring-llm' | 'done';
+
+  /** 0-based index into the active (post-skip) combo list */
+  comboIndex: number;
+
+  /** Number of active combos (skipped combos excluded) */
+  comboCount: number;
+
+  /** Current combo (UI text via combo.label; the default combos are labeled) */
+  combo?: DiffusionOffloadCombo;
+
+  /** 0-based index of the current size */
+  sizeIndex: number;
+
+  /** Number of sizes */
+  sizeCount: number;
+
+  /** Current size */
+  size?: CalibrationSize;
+
+  /** 1-based timed-sample number (timed samples only) */
+  sample?: number;
+
+  /** Timed samples per (combo, size) */
+  sampleCount?: number;
+
+  /** Progress within the current generation (0-100), when reported by sd.cpp */
+  generationPercent?: number;
+
+  /** Smooth overall sweep progress (0-100) */
+  overallPercent: number;
+}
+
+/**
+ * Result of benchmarking one (combo, size) pair
+ */
+export interface CalibrationRun {
+  /** Image size benchmarked */
+  size: CalibrationSize;
+
+  /** Combo as requested (omitted flags = auto-detect) */
+  combo: DiffusionOffloadCombo;
+
+  /** What auto-detection resolved omitted flags to for this run */
+  resolved?: {
+    clipOnCpu: boolean;
+    vaeOnCpu: boolean;
+    offloadToCpu: boolean;
+    diffusionFlashAttention: boolean;
+  };
+
+  /** Outcome: ok, out-of-memory, or other failure */
+  status: 'ok' | 'oom' | 'error';
+
+  /** Median of samplesMs (mean of the middle two for even counts); only when status === 'ok' */
+  timeTakenMs?: number;
+
+  /**
+   * Per-stage wall-clock split of the sample closest to the median
+   * (fields omitted when stage markers were missed)
+   */
+  stageMs?: { loadMs?: number; diffusionMs?: number; decodeMs?: number };
+
+  /** Raw totals of successful samples (kept even on failed runs, for diagnostics) */
+  samplesMs?: number[];
+
+  /** Failure message when status !== 'ok' */
+  error?: string;
+}
+
+/**
+ * Report returned by DiffusionServerManager.calibrate()
+ */
+export interface DiffusionCalibrationReport {
+  /** Machine fingerprint (from SystemInfo.getGPUInfo()) */
+  machine: {
+    gpuType?: string;
+    gpuName?: string;
+    vramBytes?: number;
+    vramAvailableBytes?: number;
+  };
+
+  /** Model that was calibrated */
+  modelId: string;
+
+  /** Inference steps used per generation (methodology echo for persistence keying) */
+  steps: number;
+
+  /** Sampler used (methodology echo) */
+  sampler: ImageSampler;
+
+  /** Timed samples per (combo, size) (methodology echo) */
+  samples: number;
+
+  /** All benchmark runs (one per active combo × size) */
+  runs: CalibrationRun[];
+
+  /**
+   * Fastest OK combo per size, keyed "<width>x<height>" (e.g. "768x768").
+   * Values are combos AS REQUESTED (the winner may be the empty auto combo);
+   * what auto-detection resolved to is in the winning run's `resolved`.
+   * A size where every combo failed is absent.
+   */
+  recommended: Record<string, DiffusionOffloadCombo>;
+
+  /** Combos excluded up-front (e.g. clipOnCpu combos for SD3.5-Large) */
+  skippedCombos?: { combo: DiffusionOffloadCombo; reason: string }[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,12 @@ export type {
   DiffusionServerInfo,
   GenerationStatus,
   GenerationState,
+  DiffusionOffloadCombo,
+  CalibrationSize,
+  DiffusionCalibrationConfig,
+  DiffusionCalibrationProgress,
+  CalibrationRun,
+  DiffusionCalibrationReport,
 } from './images.js';
 
 /**

--- a/tests/unit/diffusion-calibration.test.ts
+++ b/tests/unit/diffusion-calibration.test.ts
@@ -1,0 +1,846 @@
+/**
+ * Unit tests for DiffusionServerManager.calibrate() (offload calibration)
+ * and the pickRecommended pure helper.
+ *
+ * The spawn mock auto-completes each generation asynchronously and is
+ * scriptable per spawn index (exit code / stderr / hang) so the sweep's
+ * failure classification and abort paths can be exercised deterministically.
+ * Winner picking is tested as a pure function — sweep tests never assert
+ * wall-clock ordering.
+ */
+
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+import type {
+  CalibrationRun,
+  DiffusionCalibrationProgress,
+  DiffusionServerConfig,
+  ModelInfo,
+} from '../../src/types/index.js';
+
+// Mock Electron app
+const mockApp = {
+  getPath: jest.fn((name: string) => {
+    if (name === 'userData') return '/test/userData';
+    return '/test';
+  }),
+};
+
+jest.unstable_mockModule('electron', () => ({
+  app: mockApp,
+}));
+
+// Mock http module
+const mockHttpServer = new EventEmitter() as any;
+mockHttpServer.listen = jest.fn().mockImplementation((port: number, callback: () => void) => {
+  callback();
+  return mockHttpServer;
+});
+mockHttpServer.close = jest.fn().mockImplementation((callback: () => void) => {
+  callback();
+});
+
+const mockCreateServer = jest.fn().mockReturnValue(mockHttpServer);
+
+jest.unstable_mockModule('node:http', () => {
+  const httpModule = {
+    createServer: mockCreateServer,
+  };
+  return {
+    default: httpModule,
+    ...httpModule,
+  };
+});
+
+// Mock fs/promises
+const mockReadFile = jest.fn();
+const mockWriteFile = jest.fn();
+
+jest.unstable_mockModule('node:fs', () => ({
+  promises: {
+    readFile: mockReadFile,
+    writeFile: mockWriteFile,
+  },
+}));
+
+// Mock ModelManager
+const mockModelManager = {
+  getModelInfo: jest.fn(),
+};
+
+jest.unstable_mockModule('../../src/managers/ModelManager.js', () => ({
+  ModelManager: {
+    getInstance: jest.fn(() => mockModelManager),
+  },
+}));
+
+// Mock SystemInfo
+const mockSystemInfo = {
+  detect: jest.fn(),
+  canRunModel: jest.fn(),
+  getMemoryInfo: jest.fn(),
+  getGPUInfo: jest.fn(),
+  clearCache: jest.fn(),
+};
+
+jest.unstable_mockModule('../../src/system/SystemInfo.js', () => ({
+  SystemInfo: {
+    getInstance: jest.fn(() => mockSystemInfo),
+  },
+}));
+
+// Mock ProcessManager
+const mockProcessSpawn = jest.fn();
+const mockProcessKill = jest.fn();
+const mockProcessIsRunning = jest.fn();
+
+class MockProcessManager {
+  spawn = mockProcessSpawn;
+  kill = mockProcessKill;
+  isRunning = mockProcessIsRunning;
+}
+
+jest.unstable_mockModule('../../src/process/ProcessManager.js', () => ({
+  ProcessManager: MockProcessManager,
+}));
+
+// Mock LogManager
+const mockLogInitialize = jest.fn();
+const mockLogWrite = jest.fn();
+const mockLogGetRecent = jest.fn();
+const mockLogClear = jest.fn();
+
+class MockLogManager {
+  initialize = mockLogInitialize;
+  write = mockLogWrite;
+  getRecent = mockLogGetRecent;
+  clear = mockLogClear;
+  constructor(_path: string) {
+    // Path unused in tests
+  }
+}
+
+jest.unstable_mockModule('../../src/process/log-manager.js', () => ({
+  LogManager: MockLogManager,
+}));
+
+// Mock BinaryManager
+const mockEnsureBinary = jest.fn();
+
+class MockBinaryManager {
+  ensureBinary = mockEnsureBinary;
+  constructor(_config: any) {
+    // Config unused in tests
+  }
+}
+
+jest.unstable_mockModule('../../src/managers/BinaryManager.js', () => ({
+  BinaryManager: MockBinaryManager,
+}));
+
+// Mock health-check
+const mockIsServerResponding = jest.fn();
+
+jest.unstable_mockModule('../../src/process/health-check.js', () => ({
+  isServerResponding: mockIsServerResponding,
+}));
+
+// Mock port-utils (never bind real sockets in unit tests)
+const mockFindFreePort = jest.fn(async () => 49999);
+const mockIsPortBindable = jest.fn(async () => true);
+
+jest.unstable_mockModule('../../src/process/port-utils.js', () => ({
+  findFreePort: mockFindFreePort,
+  isPortBindable: mockIsPortBindable,
+}));
+
+// Mock file-utils
+const mockDeleteFile = jest.fn();
+
+jest.unstable_mockModule('../../src/utils/file-utils.js', () => ({
+  deleteFile: mockDeleteFile,
+}));
+
+// Mock paths
+const mockGetTempPath = jest.fn();
+
+jest.unstable_mockModule('../../src/config/paths.js', () => ({
+  PATHS: {
+    root: '/test',
+    models: '/test/models',
+    binaries: '/test/binaries',
+    logs: '/test/logs',
+    temp: '/test/temp',
+  },
+  getTempPath: mockGetTempPath,
+}));
+
+// Import after mocking
+const { DiffusionServerManager, pickRecommended } = await import(
+  '../../src/managers/DiffusionServerManager.js'
+);
+
+/** Script for one spawned generation (by spawn index) */
+interface SpawnScript {
+  /** Exit code (default 0) */
+  exitCode?: number;
+  /** stderr lines emitted before exit */
+  stderr?: string[];
+  /** stdout chunks emitted before exit */
+  stdout?: string[];
+  /** Never exit on its own — only via mocked kill() (abort tests) */
+  hang?: boolean;
+}
+
+describe('DiffusionServerManager calibration', () => {
+  let diffusionServer: InstanceType<typeof DiffusionServerManager>;
+
+  // 2 GB model on an 8 GB GPU → footprint 2.4 GB, headroom 5.6 GB:
+  // auto-detection resolves clipOnCpu=true, vaeOnCpu=false, offloadToCpu=false
+  const mockModelInfo: ModelInfo = {
+    id: 'sdxl-turbo',
+    name: 'SDXL Turbo',
+    type: 'diffusion',
+    size: 2 * 1024 * 1024 * 1024,
+    path: '/test/models/diffusion/sdxl-turbo.gguf',
+    downloadedAt: '2025-10-17T10:00:00Z',
+    source: {
+      type: 'url',
+      url: 'https://example.com/sdxl-turbo.gguf',
+    },
+  };
+
+  const mockServerConfig: DiffusionServerConfig = {
+    modelId: 'sdxl-turbo',
+    port: 8081,
+  };
+
+  /** Args of every spawned generation, in order */
+  let spawnCalls: string[][] = [];
+  /** Per-spawn options handles (for the kill → exit wiring) */
+  let spawnOptionsByPid: Map<number, any>;
+  /** Per-spawn-index script; return undefined for a clean instant success */
+  let spawnScript: (index: number, args: string[]) => SpawnScript | undefined;
+
+  /**
+   * Install a spawn mock where each generation auto-completes on a later tick
+   * (success by default; failures/hangs per spawnScript).
+   */
+  const installAutoSpawn = (): void => {
+    spawnCalls = [];
+    spawnOptionsByPid = new Map();
+    mockProcessSpawn.mockImplementation((_binaryPath: any, args: any, options: any) => {
+      const index = spawnCalls.length;
+      spawnCalls.push(args as string[]);
+      const pid = 1000 + index;
+      spawnOptionsByPid.set(pid, options);
+      const script = spawnScript(index, args as string[]) ?? {};
+      if (!script.hang) {
+        setTimeout(() => {
+          for (const chunk of script.stdout ?? []) {
+            options.onStdout?.(chunk);
+          }
+          for (const line of script.stderr ?? []) {
+            options.onStderr?.(line);
+          }
+          options.onExit?.(script.exitCode ?? 0, null);
+        }, 0);
+      }
+      return { pid };
+    });
+    // kill → the process "exits" (rejects as cancelled when the cancel flag is set)
+    mockProcessKill.mockImplementation(async (pid: number) => {
+      spawnOptionsByPid.get(pid)?.onExit?.(1, null);
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockLogInitialize.mockResolvedValue(undefined);
+    mockLogWrite.mockResolvedValue(undefined);
+    mockLogGetRecent.mockResolvedValue([]);
+    mockLogClear.mockResolvedValue(undefined);
+    mockEnsureBinary.mockResolvedValue('/test/binaries/sd');
+    mockCreateServer.mockReturnValue(mockHttpServer);
+    mockHttpServer.listen.mockImplementation((port: number, callback: () => void) => {
+      callback();
+      return mockHttpServer;
+    });
+    mockHttpServer.close.mockImplementation((callback: () => void) => {
+      callback();
+    });
+    mockGetTempPath.mockImplementation((filename: string) => `/test/temp/${filename}`);
+    mockDeleteFile.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(Buffer.from('fake-image-data'));
+
+    diffusionServer = new DiffusionServerManager(mockModelManager as any, mockSystemInfo as any);
+
+    mockModelManager.getModelInfo.mockResolvedValue(mockModelInfo);
+    mockSystemInfo.detect.mockResolvedValue({
+      cpu: { cores: 8, model: 'Test CPU', architecture: 'x64' },
+      memory: { total: 16 * 1024 ** 3, available: 10 * 1024 ** 3, used: 6 * 1024 ** 3 },
+      gpu: { available: true, type: 'nvidia', vram: 8 * 1024 ** 3 },
+      platform: 'linux',
+      recommendations: {
+        maxModelSize: '13B',
+        recommendedQuantization: ['Q4_K_M', 'Q5_K_M'],
+        threads: 7,
+        gpuLayers: 35,
+      },
+    });
+    mockSystemInfo.canRunModel.mockResolvedValue({ possible: true });
+    mockSystemInfo.getMemoryInfo.mockReturnValue({
+      total: 16 * 1024 ** 3,
+      available: 10 * 1024 ** 3,
+      used: 6 * 1024 ** 3,
+    });
+    mockSystemInfo.getGPUInfo.mockResolvedValue({
+      available: true,
+      type: 'nvidia',
+      name: 'RTX Test 8GB',
+      vram: 8 * 1024 ** 3,
+      vramAvailable: 7 * 1024 ** 3,
+    });
+    mockIsServerResponding.mockResolvedValue(false);
+    mockIsPortBindable.mockResolvedValue(true);
+    mockFindFreePort.mockResolvedValue(49999);
+    mockProcessKill.mockResolvedValue(undefined);
+
+    spawnScript = () => undefined; // all generations succeed by default
+    installAutoSpawn();
+  });
+
+  afterEach(() => {
+    diffusionServer.removeAllListeners();
+    mockHttpServer.removeAllListeners();
+  });
+
+  describe('pickRecommended (pure)', () => {
+    const run = (
+      width: number,
+      time: number | undefined,
+      status: CalibrationRun['status'],
+      combo: CalibrationRun['combo']
+    ): CalibrationRun => ({
+      size: { width, height: width },
+      combo,
+      status,
+      ...(time !== undefined ? { timeTakenMs: time } : {}),
+    });
+
+    it('picks the fastest OK combo per size', () => {
+      const runs = [
+        run(768, 200, 'ok', { label: 'a' }),
+        run(768, 150, 'ok', { label: 'b', clipOnCpu: false }),
+        run(768, undefined, 'oom', { label: 'c', offloadToCpu: true }),
+      ];
+      const recommended = pickRecommended(runs, 5);
+      expect(recommended['768x768']).toEqual({ label: 'b', clipOnCpu: false });
+    });
+
+    it('prefers fewer forced flags within the tolerance window', () => {
+      const runs = [
+        run(768, 100, 'ok', {
+          label: 'forced',
+          clipOnCpu: false,
+          vaeOnCpu: false,
+          offloadToCpu: true,
+        }),
+        run(768, 104, 'ok', { label: 'auto' }), // within 5% of 100 → fewer flags wins
+      ];
+      const recommended = pickRecommended(runs, 5);
+      expect(recommended['768x768']).toEqual({ label: 'auto' });
+    });
+
+    it('does not apply the tie-break outside the tolerance window', () => {
+      const runs = [
+        run(768, 100, 'ok', {
+          label: 'forced',
+          clipOnCpu: false,
+          vaeOnCpu: false,
+          offloadToCpu: true,
+        }),
+        run(768, 106, 'ok', { label: 'auto' }), // > 105 → fastest wins despite more flags
+      ];
+      const recommended = pickRecommended(runs, 5);
+      expect(recommended['768x768']!.label).toBe('forced');
+    });
+
+    it('omits sizes where every combo failed and keys sizes independently', () => {
+      const runs = [
+        run(768, undefined, 'oom', { label: 'a' }),
+        run(768, undefined, 'error', { label: 'b', clipOnCpu: false }),
+        run(512, 90, 'ok', { label: 'a' }),
+      ];
+      const recommended = pickRecommended(runs, 5);
+      expect(recommended['768x768']).toBeUndefined();
+      expect(recommended['512x512']).toEqual({ label: 'a' });
+    });
+  });
+
+  describe('guards', () => {
+    it('throws if the server is running', async () => {
+      await diffusionServer.start(mockServerConfig);
+
+      await expect(diffusionServer.calibrate({ modelId: 'sdxl-turbo' })).rejects.toThrow(
+        /Cannot calibrate while the server is running/
+      );
+
+      await diffusionServer.stop();
+    });
+
+    it('rejects invalid sizes (non-multiple of 64) before any spawn', async () => {
+      await expect(
+        diffusionServer.calibrate({
+          modelId: 'sdxl-turbo',
+          sizes: [{ width: 500, height: 512 }],
+        })
+      ).rejects.toThrow(/multiples of 64/);
+      expect(mockProcessSpawn).not.toHaveBeenCalled();
+    });
+
+    it('rejects a pre-aborted signal immediately with empty partial runs', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      try {
+        await diffusionServer.calibrate({ modelId: 'sdxl-turbo', signal: controller.signal });
+        throw new Error('Should have thrown');
+      } catch (error: any) {
+        expect(error.code).toBe('SERVER_ERROR'); // top-level code is generic
+        expect(error.details.code).toBe('CALIBRATION_ABORTED');
+        expect(error.details.runs).toEqual([]);
+      }
+      expect(mockProcessSpawn).not.toHaveBeenCalled();
+      expect(diffusionServer.isCalibrating()).toBe(false);
+    });
+
+    it('blocks start() while a calibration is in flight', async () => {
+      let startRejection: Promise<void> | undefined;
+      const calibratePromise = diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        onProgress: (p) => {
+          if (p.phase === 'warmup' && !startRejection) {
+            expect(diffusionServer.isCalibrating()).toBe(true);
+            startRejection = expect(diffusionServer.start(mockServerConfig)).rejects.toThrow(
+              /calibration is in progress/
+            );
+          }
+        },
+        combos: [{ label: 'auto' }],
+      });
+
+      await calibratePromise;
+      expect(startRejection).toBeDefined();
+      await startRejection;
+      expect(diffusionServer.isCalibrating()).toBe(false);
+    });
+  });
+
+  describe('sweep structure and per-run flag resolution', () => {
+    it('spawns combos × (warmup + samples × sizes) and applies per-combo flags', async () => {
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        sizes: [
+          { width: 768, height: 768 },
+          { width: 512, height: 1024 },
+        ],
+        samples: 1,
+        steps: 4,
+        combos: [
+          { label: 'clip-gpu', clipOnCpu: false },
+          { label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true },
+        ],
+      });
+
+      // 2 combos × (1 warmup + 1 sample × 2 sizes) = 6 generations
+      expect(spawnCalls).toHaveLength(6);
+
+      // Combo 1 (clipOnCpu: false overrides auto=true): no offload flags at all
+      for (const args of spawnCalls.slice(0, 3)) {
+        expect(args).not.toContain('--clip-on-cpu');
+        expect(args).not.toContain('--vae-on-cpu');
+        expect(args).not.toContain('--offload-to-cpu');
+      }
+      // Combo 2: all three forced on
+      for (const args of spawnCalls.slice(3, 6)) {
+        expect(args).toContain('--clip-on-cpu');
+        expect(args).toContain('--vae-on-cpu');
+        expect(args).toContain('--offload-to-cpu');
+      }
+
+      // Identical work per generation: fixed seed/steps/sampler; warmup at first size
+      for (const args of spawnCalls) {
+        expect(args).toContain('-s');
+        expect(args[args.indexOf('-s') + 1]).toBe('42');
+        expect(args).toContain('--steps');
+        expect(args[args.indexOf('--steps') + 1]).toBe('4');
+        expect(args).toContain('--sampling-method');
+        expect(args[args.indexOf('--sampling-method') + 1]).toBe('euler');
+      }
+      const sizeOf = (args: string[]): string =>
+        `${args[args.indexOf('-W') + 1]}x${args[args.indexOf('-H') + 1]}`;
+      expect(sizeOf(spawnCalls[0]!)).toBe('768x768'); // warmup @ first size
+      expect(sizeOf(spawnCalls[1]!)).toBe('768x768');
+      expect(sizeOf(spawnCalls[2]!)).toBe('512x1024');
+
+      // One run per (combo, size), all OK, with timings and resolved flags
+      expect(report.runs).toHaveLength(4);
+      for (const calRun of report.runs) {
+        expect(calRun.status).toBe('ok');
+        expect(calRun.timeTakenMs).toBeDefined();
+        expect(calRun.samplesMs).toHaveLength(1);
+        expect(calRun.resolved).toBeDefined();
+      }
+      // Combo 1 resolved: override wins over auto (auto would be clip=true)
+      const clipGpuRun = report.runs.find(
+        (r) => r.combo.label === 'clip-gpu' && r.size.width === 768
+      )!;
+      expect(clipGpuRun.resolved!.clipOnCpu).toBe(false);
+
+      // Recommendation exists for both sizes; methodology echo present
+      expect(report.recommended['768x768']).toBeDefined();
+      expect(report.recommended['512x1024']).toBeDefined();
+      expect(report.steps).toBe(4);
+      expect(report.sampler).toBe('euler');
+      expect(report.samples).toBe(1);
+      expect(report.modelId).toBe('sdxl-turbo');
+      expect(report.machine.gpuName).toBe('RTX Test 8GB');
+      expect(report.machine.vramBytes).toBe(8 * 1024 ** 3);
+
+      // Server left stopped, state restored
+      expect(diffusionServer.getStatus()).toBe('stopped');
+      expect(diffusionServer.isCalibrating()).toBe(false);
+    });
+
+    it('lets auto-detection resolve omitted flags (auto combo carries resolved values)', async () => {
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [{ label: 'auto' }],
+      });
+
+      // 8 GB GPU, 2 GB model → auto: clip=true, vae=false, offload=false
+      for (const args of spawnCalls) {
+        expect(args).toContain('--clip-on-cpu');
+        expect(args).not.toContain('--vae-on-cpu');
+        expect(args).not.toContain('--offload-to-cpu');
+      }
+      const calRun = report.runs[0]!;
+      expect(calRun.resolved).toEqual({
+        clipOnCpu: true,
+        vaeOnCpu: false,
+        offloadToCpu: false,
+        diffusionFlashAttention: false,
+      });
+      // Recommended combo is the AS-REQUESTED combo (auto), not the resolved flags
+      expect(report.recommended['768x768']).toEqual({ label: 'auto' });
+    });
+  });
+
+  describe('failure classification', () => {
+    it('classifies an OOM combo, continues the sweep, and excludes it from recommendation', async () => {
+      // Combo B's warmup (spawn index 2) crashes with CUDA OOM
+      spawnScript = (index) =>
+        index === 2
+          ? { exitCode: 1, stderr: ['ggml_cuda_host_malloc: CUDA error: out of memory'] }
+          : undefined;
+
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [
+          { label: 'auto' },
+          { label: 'all-resident', clipOnCpu: false, vaeOnCpu: false, offloadToCpu: false },
+        ],
+      });
+
+      // Combo A: warmup + 1 sample; combo B: failed warmup only (samples skipped)
+      expect(spawnCalls).toHaveLength(3);
+
+      const okRun = report.runs.find((r) => r.combo.label === 'auto')!;
+      const oomRun = report.runs.find((r) => r.combo.label === 'all-resident')!;
+      expect(okRun.status).toBe('ok');
+      expect(oomRun.status).toBe('oom');
+      expect(oomRun.error).toContain('exited with code 1');
+      expect(oomRun.timeTakenMs).toBeUndefined();
+
+      expect(report.recommended['768x768']).toEqual({ label: 'auto' });
+    });
+
+    it('classifies a non-OOM failure as error and keeps successful samplesMs', async () => {
+      // Second timed sample (spawn index 2: warmup, sample1, sample2) fails generically
+      spawnScript = (index) =>
+        index === 2 ? { exitCode: 1, stderr: ['some unrelated failure'] } : undefined;
+
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 2,
+        combos: [{ label: 'auto' }],
+      });
+
+      expect(spawnCalls).toHaveLength(3);
+      const calRun = report.runs[0]!;
+      expect(calRun.status).toBe('error');
+      expect(calRun.samplesMs).toHaveLength(1); // first sample kept for diagnostics
+      expect(calRun.timeTakenMs).toBeUndefined(); // never recommended
+      expect(report.recommended['768x768']).toBeUndefined();
+    });
+
+    it('records a warmup failure on the first size but still attempts later sizes', async () => {
+      const progress: DiffusionCalibrationProgress[] = [];
+      // Warmup (spawn 0) OOMs; the second size's sample (spawn 1) succeeds
+      spawnScript = (index) =>
+        index === 0 ? { exitCode: 1, stderr: ['cudaMalloc failed: out of memory'] } : undefined;
+
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        sizes: [
+          { width: 768, height: 768 },
+          { width: 512, height: 512 },
+        ],
+        samples: 1,
+        combos: [{ label: 'auto' }],
+        onProgress: (p) => progress.push(p),
+      });
+
+      expect(spawnCalls).toHaveLength(2); // failed warmup + second size's sample
+
+      const firstSizeRun = report.runs.find((r) => r.size.width === 768)!;
+      const secondSizeRun = report.runs.find((r) => r.size.width === 512)!;
+      expect(firstSizeRun.status).toBe('oom');
+      expect(secondSizeRun.status).toBe('ok');
+
+      // Progress still reaches 100 despite the skipped units
+      expect(progress[progress.length - 1]!.phase).toBe('done');
+      expect(progress[progress.length - 1]!.overallPercent).toBe(100);
+    });
+  });
+
+  describe('progress reporting', () => {
+    it('reports phases in order, monotonic 0→100, with event parity', async () => {
+      const callbackPayloads: DiffusionCalibrationProgress[] = [];
+      const eventPayloads: DiffusionCalibrationProgress[] = [];
+      diffusionServer.on('calibration-progress', (p: DiffusionCalibrationProgress) =>
+        eventPayloads.push(p)
+      );
+
+      await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [{ label: 'auto' }, { label: 'clip-gpu', clipOnCpu: false }],
+        onProgress: (p) => callbackPayloads.push(p),
+      });
+
+      // Same payload stream on both channels
+      expect(eventPayloads).toEqual(callbackPayloads);
+
+      // Phase ordering: preparing first, done last, warmup before its sampling
+      expect(callbackPayloads[0]!.phase).toBe('preparing');
+      expect(callbackPayloads[0]!.overallPercent).toBe(0);
+      expect(callbackPayloads[callbackPayloads.length - 1]!.phase).toBe('done');
+      expect(callbackPayloads[callbackPayloads.length - 1]!.overallPercent).toBe(100);
+      const phases = callbackPayloads.map((p) => p.phase);
+      expect(phases).toContain('warmup');
+      expect(phases).toContain('sampling');
+      expect(phases.indexOf('warmup')).toBeLessThan(phases.indexOf('sampling'));
+
+      // Monotonic overall percent
+      for (let i = 1; i < callbackPayloads.length; i++) {
+        expect(callbackPayloads[i]!.overallPercent).toBeGreaterThanOrEqual(
+          callbackPayloads[i - 1]!.overallPercent
+        );
+      }
+
+      // Combo context present on warmup/sampling payloads
+      const sampling = callbackPayloads.find((p) => p.phase === 'sampling')!;
+      expect(sampling.combo).toBeDefined();
+      expect(sampling.comboCount).toBe(2);
+      expect(sampling.sampleCount).toBe(1);
+    });
+
+    it('survives throwing onProgress callbacks and event listeners', async () => {
+      diffusionServer.on('calibration-progress', () => {
+        throw new Error('listener boom');
+      });
+
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [{ label: 'auto' }],
+        onProgress: () => {
+          throw new Error('callback boom');
+        },
+      });
+
+      expect(report.runs).toHaveLength(1);
+      expect(report.runs[0]!.status).toBe('ok');
+    });
+  });
+
+  describe('abort', () => {
+    it('aborts between generations with partial runs attached', async () => {
+      const controller = new AbortController();
+
+      try {
+        await diffusionServer.calibrate({
+          modelId: 'sdxl-turbo',
+          samples: 1,
+          combos: [{ label: 'auto' }, { label: 'clip-gpu', clipOnCpu: false }],
+          signal: controller.signal,
+          onProgress: (p) => {
+            // Abort when the second combo is about to warm up
+            if (p.phase === 'warmup' && p.comboIndex === 1) {
+              controller.abort();
+            }
+          },
+        });
+        throw new Error('Should have thrown');
+      } catch (error: any) {
+        expect(error.code).toBe('SERVER_ERROR');
+        expect(error.details.code).toBe('CALIBRATION_ABORTED');
+        // Combo A's run completed before the abort
+        expect(error.details.runs).toHaveLength(1);
+        expect(error.details.runs[0].combo.label).toBe('auto');
+      }
+
+      expect(diffusionServer.isCalibrating()).toBe(false);
+      // A fresh calibrate works afterwards (state fully torn down)
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [{ label: 'auto' }],
+      });
+      expect(report.runs[0]!.status).toBe('ok');
+    });
+
+    it('aborts an in-flight generation via the cancel path', async () => {
+      const controller = new AbortController();
+      // Second spawn hangs; abort fires while it is in flight
+      spawnScript = (index) => {
+        if (index === 1) {
+          setTimeout(() => controller.abort(), 10);
+          return { hang: true };
+        }
+        return undefined;
+      };
+
+      try {
+        await diffusionServer.calibrate({
+          modelId: 'sdxl-turbo',
+          samples: 1,
+          combos: [{ label: 'auto' }],
+          signal: controller.signal,
+        });
+        throw new Error('Should have thrown');
+      } catch (error: any) {
+        expect(error.details.code).toBe('CALIBRATION_ABORTED');
+      }
+
+      // The hanging process was killed via the cancel path
+      expect(mockProcessKill).toHaveBeenCalled();
+      expect(diffusionServer.isCalibrating()).toBe(false);
+    });
+  });
+
+  describe('SD3.5-Large guard', () => {
+    it('skips clipOnCpu combos for SD3.5-Large models and records them', async () => {
+      mockModelManager.getModelInfo.mockResolvedValue({
+        ...mockModelInfo,
+        id: 'sd3.5-large-q4',
+        name: 'Stable Diffusion 3.5 Large',
+      });
+
+      const report = await diffusionServer.calibrate({
+        modelId: 'sd3.5-large-q4',
+        samples: 1,
+      });
+
+      // Default set has exactly one clipOnCpu: true combo (max-savings)
+      expect(report.skippedCombos).toHaveLength(1);
+      expect(report.skippedCombos![0]!.combo.label).toBe('max-savings');
+      expect(report.skippedCombos![0]!.reason).toContain('1578');
+
+      // 5 active combos × (1 warmup + 1 sample × 1 size) = 10 generations
+      expect(report.runs).toHaveLength(5);
+      expect(spawnCalls).toHaveLength(10);
+      expect(report.runs.every((r) => r.combo.clipOnCpu !== true)).toBe(true);
+    });
+  });
+
+  describe('LLM orchestration', () => {
+    it('offloads a running LLM once at sweep start and restores it at the end', async () => {
+      const callOrder: string[] = [];
+      const llmConfig = { modelId: 'llama-test', port: 8080 };
+      const mockLlamaServer: any = {
+        isRunning: jest.fn(() => true),
+        getConfig: jest.fn(() => llmConfig),
+        stop: jest.fn(async () => {
+          callOrder.push('llm-stop');
+        }),
+        start: jest.fn(async () => {
+          callOrder.push('llm-start');
+          return {};
+        }),
+      };
+      const server = new DiffusionServerManager(
+        mockModelManager as any,
+        mockSystemInfo as any,
+        mockLlamaServer
+      );
+      const phases: string[] = [];
+
+      const report = await server.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [{ label: 'auto' }],
+        onProgress: (p) => phases.push(p.phase),
+      });
+
+      // Offloaded exactly once, before the first generation; restored once after
+      expect(mockLlamaServer.stop).toHaveBeenCalledTimes(1);
+      expect(mockLlamaServer.start).toHaveBeenCalledTimes(1);
+      expect(mockLlamaServer.start).toHaveBeenCalledWith(llmConfig);
+      expect(callOrder).toEqual(['llm-stop', 'llm-start']);
+      expect(phases).toContain('restoring-llm');
+      // done comes after the restore
+      expect(phases.indexOf('restoring-llm')).toBeLessThan(phases.indexOf('done'));
+      expect(report.runs[0]!.status).toBe('ok');
+
+      server.removeAllListeners();
+    });
+  });
+
+  describe('state restore', () => {
+    it('restores server state so a normal start()+generateImage() works afterwards', async () => {
+      // Establish prior state: a started-then-stopped server keeps its config
+      await diffusionServer.start(mockServerConfig);
+      await diffusionServer.stop();
+      const configBefore = diffusionServer.getConfig();
+
+      await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        combos: [{ label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true }],
+      });
+
+      // Config restored (not the synthetic calibration config)
+      expect(diffusionServer.getConfig()).toBe(configBefore);
+      expect(diffusionServer.getStatus()).toBe('stopped');
+
+      // Normal operation unaffected — and no leftover combo overrides
+      spawnCalls = [];
+      await diffusionServer.start(mockServerConfig);
+      const result = await diffusionServer.generateImage({ prompt: 'test' });
+      expect(result.image).toEqual(Buffer.from('fake-image-data'));
+      const lastArgs = spawnCalls[spawnCalls.length - 1]!;
+      // Auto flags for this model/GPU: clip on CPU only (not the forced max-savings set)
+      expect(lastArgs).toContain('--clip-on-cpu');
+      expect(lastArgs).not.toContain('--vae-on-cpu');
+      expect(lastArgs).not.toContain('--offload-to-cpu');
+      await diffusionServer.stop();
+    });
+  });
+});

--- a/tests/unit/diffusion-calibration.test.ts
+++ b/tests/unit/diffusion-calibration.test.ts
@@ -179,6 +179,7 @@ jest.unstable_mockModule('../../src/config/paths.js', () => ({
 const { DiffusionServerManager, pickRecommended } = await import(
   '../../src/managers/DiffusionServerManager.js'
 );
+const { DIFFUSION_CALIBRATION_DEFAULTS } = await import('../../src/config/defaults.js');
 
 /** Script for one spawned generation (by spawn index) */
 interface SpawnScript {
@@ -437,6 +438,27 @@ describe('DiffusionServerManager calibration', () => {
       await startRejection;
       expect(diffusionServer.isCalibrating()).toBe(false);
     });
+
+    it('rejects a second calibrate() while one is in flight', async () => {
+      let secondRejection: Promise<void> | undefined;
+      const calibratePromise = diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 1,
+        onProgress: (p) => {
+          if (p.phase === 'warmup' && !secondRejection) {
+            secondRejection = expect(
+              diffusionServer.calibrate({ modelId: 'sdxl-turbo' })
+            ).rejects.toThrow(/already in progress/);
+          }
+        },
+        combos: [{ label: 'auto' }],
+      });
+
+      await calibratePromise;
+      expect(secondRejection).toBeDefined();
+      await secondRejection;
+      expect(diffusionServer.isCalibrating()).toBe(false);
+    });
   });
 
   describe('sweep structure and per-run flag resolution', () => {
@@ -537,6 +559,72 @@ describe('DiffusionServerManager calibration', () => {
       });
       // Recommended combo is the AS-REQUESTED combo (auto), not the resolved flags
       expect(report.recommended['768x768']).toEqual({ label: 'auto' });
+    });
+  });
+
+  describe('stage timing and medians (stdout-driven)', () => {
+    // Realistic sd-cli stdout for one generation (sd.cpp master-746 literals)
+    const SD_STDOUT = [
+      'loading model from /test/models/diffusion/sdxl-turbo.gguf\n',
+      'generating image: 1/1 - seed 42\n',
+      '  |==>               | 2/4 - 1.50it/s\n',
+      '  |=========>        | 4/4 - 1.45it/s\n',
+      'decoding 1 latents\n',
+      'decode_first_stage completed, taking 1.23s\n',
+    ];
+
+    it('populates stageMs from stdout markers and medians multi-sample timings', async () => {
+      spawnScript = () => ({ stdout: [...SD_STDOUT] });
+      const progressEvents: DiffusionCalibrationProgress[] = [];
+
+      const report = await diffusionServer.calibrate({
+        modelId: 'sdxl-turbo',
+        samples: 2,
+        steps: 4,
+        combos: [{ label: 'auto' }],
+        onProgress: (p) => progressEvents.push(p),
+      });
+
+      // 1 combo × (1 warmup + 2 samples) = 3 generations
+      expect(spawnCalls).toHaveLength(3);
+      const calRun = report.runs[0]!;
+      expect(calRun.status).toBe('ok');
+
+      // Happy-path median of two samples = mean of the pair
+      expect(calRun.samplesMs).toHaveLength(2);
+      const [s1, s2] = calRun.samplesMs!;
+      expect(calRun.timeTakenMs).toBeCloseTo((s1! + s2!) / 2, 5);
+
+      // Stage split extracted from the stdout stage markers (instant mock → 0 ms is fine)
+      expect(calRun.stageMs).toBeDefined();
+      expect(calRun.stageMs!.loadMs).toBeGreaterThanOrEqual(0);
+      expect(calRun.stageMs!.diffusionMs).toBeGreaterThanOrEqual(0);
+      expect(calRun.stageMs!.decodeMs).toBeGreaterThanOrEqual(0);
+
+      // The step bars drove within-generation progress into the sweep stream...
+      expect(
+        progressEvents.some(
+          (p) =>
+            (p.phase === 'warmup' || p.phase === 'sampling') && p.generationPercent !== undefined
+        )
+      ).toBe(true);
+      // ...and overall stays monotonic through the fractional folding
+      let last = -1;
+      for (const p of progressEvents) {
+        expect(p.overallPercent).toBeGreaterThanOrEqual(last);
+        last = p.overallPercent;
+      }
+    });
+
+    it('hands back per-sweep combo copies, never the module default objects', async () => {
+      const report = await diffusionServer.calibrate({ modelId: 'sdxl-turbo', samples: 1 });
+
+      // Default sweep: 6 combos × (1 warmup + 1 sample × 1 size) = 12 generations
+      expect(spawnCalls).toHaveLength(12);
+      const firstDefault = DIFFUSION_CALIBRATION_DEFAULTS.combos[0]!;
+      const firstRun = report.runs.find((r) => r.combo.label === firstDefault.label)!;
+      expect(firstRun.combo).toEqual(firstDefault);
+      expect(firstRun.combo).not.toBe(firstDefault); // mutation-safe copy
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a per-machine **offload calibration sweep** to \`DiffusionServerManager\` (implements \`docs/dev/issues/ISSUE-diffusion-offload-calibration.md\`): benchmark CPU-offload flag combinations (\`clipOnCpu\`/\`vaeOnCpu\`/\`offloadToCpu\`/\`diffusionFlashAttention\`) × image sizes with real generations and return the fastest working combo per size.

- **No server restarts** — flags resolve per generation via \`computeDiffusionOptimizations()\` overrides; server must be stopped and is left stopped
- 6 curated default combos, 1 discarded warmup + median-of-2-samples timing, per-stage split (\`stageMs\`), OOM-vs-error classification
- Per-size \`recommended\` with 5% tie tolerance preferring fewer forced flags
- First-class progress: guarded \`onProgress\` callback + \`'calibration-progress'\` event (monotonic \`overallPercent\`, IPC-forwardable)
- Abort via \`AbortSignal\` → \`ServerError\` with \`details.code='CALIBRATION_ABORTED'\` + partial runs
- Sweep-level LLM offload/restore via ResourceOrchestrator (\`offloadLLM()\`/\`reloadLLM()\` promoted to public)
- SD3.5-Large \`--clip-on-cpu\` combos auto-skipped (upstream leejet/stable-diffusion.cpp#1578)
- Example app: Calibrate card with progress bar, results table, apply-recommended-flags
- Docs: new "Offload Calibration" section + typescript-reference + resource-orchestration

## Verification

- 566/566 tests (23 new calibration cases), 0 TS errors, lint clean
- **Live smoke passed** (RTX 4060 Laptop 8 GB, flux-2-klein-q40 @ 768²/4-step): recommended \`clip-gpu\` 17.1 s median vs auto 33.5 s (~2×); \`vaeOnCpu\` decode trap confirmed (97.3 s); tie-break exercised live; post-sweep \`start()\`+generation OK
- Final doublecheck (3 independent reviewers): zero critical/important findings; minor hardening applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f