### PR TITLE
release: v0.11.0 — diffusion offload calibration

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,38 +1,15 @@
 # genai-electron Implementation Progress
 
-> **Current Status**: v0.10.0 released — diffusion offload calibration accumulating unreleased (2026-07-04)
+> **Current Status**: v0.11.0 released — diffusion offload calibration (2026-07-04)
 
 ---
 
 ## Current Build Status
 
 - **Build:** ✅ 0 TypeScript errors
-- **Tests:** ✅ 563/563 passing (22 suites)
-- **Branch:** `feat/diffusion-calibration` (unreleased batch)
-- **Last Updated:** 2026-07-04 (offload calibration)
-
----
-
-## Unreleased
-
-### Diffusion Offload Calibration — `diffusionServer.calibrate()` (2026-07-04)
-
-**Goal/Problem:** The static VRAM heuristic cannot pick the fastest CPU-offload flag combo — the optimum is machine-dependent and the flags interact (measured on an 8 GB Win11 laptop with Flux 2 Klein: auto ~18 s vs `clipOnCpu:false`+`offloadToCpu:true` ~10–12 s; `vaeOnCpu` ~3× slower; Windows thrashes where Linux hard-OOMs). Only a live sweep on the target machine can decide. Proposal: `docs/dev/issues/ISSUE-diffusion-offload-calibration.md`; plan: `docs/dev/plans/PLAN-diffusion-calibration.md`.
-
-**Core Features:**
-- `calibrate(config)` on DiffusionServerManager: benchmarks offload combos × sizes with real generations (fixed seed/steps/prompt/sampler → identical work per combo), 1 discarded warmup per combo + median-of-samples timing, per-stage split (`stageMs`: load/diffusion/decode), OOM-vs-error classification from stderr/exit code, per-size `recommended` (5% tie tolerance prefers fewer forced flags)
-- **No server restarts:** per-generation flag overrides threaded through `computeDiffusionOptimizations` (flags resolve per spawn); server must be stopped, is left stopped; `start()` guarded during sweeps; `isCalibrating()`
-- Sweep-level LLM offload/restore via the internal orchestrator (`waitForReload()` → `offloadLLM()` once, `reloadLLM()` in finally; both promoted to public API)
-- Progress for UIs: guarded `onProgress` callback + `'calibration-progress'` event (same payload; smooth monotonic `overallPercent` with within-generation folding) — IPC-forwardable like `'binary-progress'`
-- Abort via `AbortSignal` → `ServerError` with `details.code = 'CALIBRATION_ABORTED'` + partial runs in `details.runs`
-- SD3.5-Large guard: forced `clipOnCpu: true` combos auto-skipped → `report.skippedCombos` (upstream leejet/stable-diffusion.cpp#1578)
-- New exports: `DiffusionOffloadCombo`, `CalibrationSize`, `DiffusionCalibrationConfig/Progress/Report`, `CalibrationRun`, `DIFFUSION_CALIBRATION_DEFAULTS`
-
-**Files Modified:** `src/types/{images,index}.ts`, `src/index.ts`, `src/config/defaults.ts`, `src/managers/{DiffusionServerManager,ResourceOrchestrator}.ts`, `tests/unit/diffusion-calibration.test.ts` (new, 23 cases), docs (`image-generation` "Offload Calibration" section, `typescript-reference`, `resource-orchestration`, index/troubleshooting cross-refs), example app (calibration UI)
-
-**Build Status:** ✅ 0 TypeScript errors / 566/566 tests passing (22 suites)
-
-**Live smoke (2026-07-04, RTX 4060 Laptop 8 GB, flux-2-klein-q40 768²/4-step):** full default sweep passed — recommended `clip-gpu` at 17.1 s median vs auto's 33.5 s (~2×); `vaeOnCpu` decode trap confirmed (97.3 s, decode 66 s); 5% tie-break exercised live (`all-resident` 16.9 s / `clip-gpu` 17.1 s / `clip-gpu+offload` 17.4 s → fewest forced flags won); progress monotonic, phases in order, callback/event parity (2303 events); post-sweep normal `start()` + generation with recommended flags OK, server left stopped. Details: `docs/dev/plans/PLAN-diffusion-calibration.md` Phase 6.
+- **Tests:** ✅ 566/566 passing (22 suites)
+- **Branch:** `main` (v0.11.0)
+- **Last Updated:** 2026-07-04 (v0.11.0 release)
 
 ---
 
@@ -544,6 +521,27 @@ For detailed historical information:
 **Files Modified:** `src/utils/kv-cache-math.ts` (new), `src/utils/model-metadata-helpers.ts`, `src/system/SystemInfo.ts`, `src/managers/{LlamaServerManager,ModelManager,ResourceOrchestrator}.ts`, `src/config/defaults.ts`, `src/types/{models,servers,index}.ts`, `src/index.ts`, docs (`system-detection`, `llm-server`, `typescript-reference`, `image-generation`, `migration-0-6-to-0-7.md`)
 
 **Build Status:** ✅ 0 TypeScript errors / 514/514 tests passing (21 suites); v0.7.1 adds the progressive context-granularity ladder (128→4096 steps by magnitude, `floorContextToGranularity` exported; amends unpublished v0.7.0 — publish 0.7.1). Live GPU smoke: pure auto-config on Qwen3.5-4B → full offload, auto q8_0 KV + FA, context 58368 (→ 57344 with the ladder), 8130-token prompt round-trips without truncation
+
+---
+
+## v0.11.0: Diffusion Offload Calibration — `diffusionServer.calibrate()` (2026-07-04)
+
+**Goal/Problem:** The static VRAM heuristic cannot pick the fastest CPU-offload flag combo — the optimum is machine-dependent and the flags interact (measured on an 8 GB Win11 laptop with Flux 2 Klein: auto ~18 s vs `clipOnCpu:false`+`offloadToCpu:true` ~10–12 s; `vaeOnCpu` ~3× slower; Windows thrashes where Linux hard-OOMs). Only a live sweep on the target machine can decide. Proposal: `docs/dev/issues/ISSUE-diffusion-offload-calibration.md`; plan: `docs/dev/plans/PLAN-diffusion-calibration.md`.
+
+**Core Features:**
+- `calibrate(config)` on DiffusionServerManager: benchmarks offload combos × sizes with real generations (fixed seed/steps/prompt/sampler → identical work per combo), 1 discarded warmup per combo + median-of-samples timing, per-stage split (`stageMs`: load/diffusion/decode), OOM-vs-error classification from stderr/exit code, per-size `recommended` (5% tie tolerance prefers fewer forced flags)
+- **No server restarts:** per-generation flag overrides threaded through `computeDiffusionOptimizations` (flags resolve per spawn); server must be stopped, is left stopped; `start()` guarded during sweeps; `isCalibrating()`
+- Sweep-level LLM offload/restore via the internal orchestrator (`waitForReload()` → `offloadLLM()` once, `reloadLLM()` in finally; both promoted to public API)
+- Progress for UIs: guarded `onProgress` callback + `'calibration-progress'` event (same payload; smooth monotonic `overallPercent` with within-generation folding) — IPC-forwardable like `'binary-progress'`
+- Abort via `AbortSignal` → `ServerError` with `details.code = 'CALIBRATION_ABORTED'` + partial runs in `details.runs`
+- SD3.5-Large guard: forced `clipOnCpu: true` combos auto-skipped → `report.skippedCombos` (upstream leejet/stable-diffusion.cpp#1578)
+- New exports: `DiffusionOffloadCombo`, `CalibrationSize`, `DiffusionCalibrationConfig/Progress/Report`, `CalibrationRun`, `DIFFUSION_CALIBRATION_DEFAULTS`
+
+**Files Modified:** `src/types/{images,index}.ts`, `src/index.ts`, `src/config/defaults.ts`, `src/managers/{DiffusionServerManager,ResourceOrchestrator}.ts`, `tests/unit/diffusion-calibration.test.ts` (new, 23 cases), docs (`image-generation` "Offload Calibration" section, `typescript-reference`, `resource-orchestration`, index/troubleshooting cross-refs, `migration-0-10-to-0-11.md`), example app (calibration UI)
+
+**Build Status:** ✅ 0 TypeScript errors / 566/566 tests passing (22 suites)
+
+**Live smoke (2026-07-04, RTX 4060 Laptop 8 GB, flux-2-klein-q40 768²/4-step):** full default sweep passed — recommended `clip-gpu` at 17.1 s median vs auto's 33.5 s (~2×); `vaeOnCpu` decode trap confirmed (97.3 s, decode 66 s); 5% tie-break exercised live (`all-resident` 16.9 s / `clip-gpu` 17.1 s / `clip-gpu+offload` 17.4 s → fewest forced flags won); progress monotonic, phases in order, callback/event parity (2303 events); post-sweep normal `start()` + generation with recommended flags OK, server left stopped. Details: `docs/dev/plans/PLAN-diffusion-calibration.md` Phase 6.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai-electron
 
-> **Version**: 0.10.0 | **Status**: Production Ready - LLM & Image Generation, refreshed stable-diffusion.cpp runtime
+> **Version**: 0.11.0 | **Status**: Production Ready - LLM & Image Generation, per-machine offload calibration
 
 Electron-specific library for managing local AI model servers (llama.cpp, stable-diffusion.cpp). Handles platform-specific operations to run AI models locally. Complements [genai-lite](https://github.com/lacerbi/genai-lite) for API abstraction.
 

--- a/docs/dev/plans/PLAN-diffusion-calibration.md
+++ b/docs/dev/plans/PLAN-diffusion-calibration.md
@@ -1,7 +1,7 @@
 # Plan: Diffusion Offload Calibration API (`diffusionServer.calibrate()`)
 
 Created: 2026-07-04
-Status: COMPLETE (2026-07-04) — all phases done, live smoke PASSED, doublecheck clean; ships unreleased per the batch workflow
+Status: COMPLETE (2026-07-04) — all phases done, live smoke PASSED, doublecheck clean; **released as v0.11.0** (feature PR #38 → release PR)
 Source: `ISSUE-diffusion-offload-calibration.md` (repo root) + design discussion (agreed decisions below)
 
 ## Phase status
@@ -531,6 +531,11 @@ version-adjacent change). When the user later says to release: one release PR bu
 package.json / `src/index.ts` `@version` / README, adds the PROGRESS release entry and any
 migration notes, then tag → GitHub release → user runs `npm publish`. Merge/PR timing decided
 by the user at the end.
+
+**Released 2026-07-04 as v0.11.0** (user go-ahead same day): feature PR #38 merged with green
+CI (6/6 checks) → `release/v0.11.0` (version strings, `migration-0-10-to-0-11.md`, PROGRESS
+entry moved from "Unreleased" to a v0.11.0 section, docs index migration link) → release PR →
+tag `v0.11.0` → GitHub release → user `npm publish`. Purely additive — no migration steps.
 
 ## Open questions
 

--- a/genai-electron-docs/index.md
+++ b/genai-electron-docs/index.md
@@ -1,6 +1,6 @@
 # genai-electron Documentation
 
-> **Version**: 0.10.0 (stable-diffusion.cpp master-746 + CUDA offload auto-detection)
+> **Version**: 0.11.0 (offload calibration: `diffusionServer.calibrate()`)
 > **Status**: Production Ready - LLM & Image Generation
 
 Complete documentation for genai-electron - An Electron-specific library for managing local AI model servers and resources.
@@ -26,6 +26,7 @@ Complete documentation for genai-electron - An Electron-specific library for man
 - **[Troubleshooting](troubleshooting.md)** - Common issues, error codes, FAQ
 
 ### Migration
+- **[Migrating from v0.10.x to v0.11.0](migration-0-10-to-0-11.md)** - Offload calibration (`calibrate()`); purely additive, nothing to migrate
 - **[Migrating from v0.9.x to v0.10.0](migration-0-9-to-0-10.md)** - stable-diffusion.cpp master-746 bump; CPU-offload flags now auto-detected on CUDA too
 - **[Migrating from v0.8.x to v0.9.0](migration-0-8-to-0-9.md)** - Structured `'binary-progress'` event for provisioning UIs
 - **[Migrating from v0.7.x to v0.8.0](migration-0-7-to-0-8.md)** - MoE-aware sizing: automatic `cpuMoe` for too-big MoE models, expert-weights measurement

--- a/genai-electron-docs/migration-0-10-to-0-11.md
+++ b/genai-electron-docs/migration-0-10-to-0-11.md
@@ -1,0 +1,47 @@
+# Migrating from v0.10.x to v0.11.0
+
+v0.11.0 adds **offload calibration** — a purely additive release. No breaking changes, no behavioral changes to existing APIs, no binary re-download (the sd.cpp pin is unchanged).
+
+## Compatibility
+
+Fully API-compatible: nothing to migrate. Upgrade and go.
+
+Two additions worth knowing about:
+
+- `ResourceOrchestrator.offloadLLM()` / `reloadLLM()` are now **public** (previously private). Existing orchestration behavior is unchanged — they were promoted so `calibrate()` (and your code, if useful) can drive sweep-level LLM offload explicitly.
+- `DiffusionServerManager` emits a new `'calibration-progress'` event. Existing event listeners are unaffected.
+
+## What's New
+
+### `diffusionServer.calibrate()` — pick offload flags by measuring, not guessing
+
+The static VRAM heuristic can't know which CPU-offload flag combination (`clipOnCpu` / `vaeOnCpu` / `offloadToCpu` / `diffusionFlashAttention`) is fastest on a given machine — the optimum is hardware-dependent and the flags interact. `calibrate()` benchmarks curated combinations with real generations (server stopped, no restarts — flags resolve per generation) and returns per-combo timings, per-stage splits, OOM/error classification, and a recommended combo per image size:
+
+```typescript
+const report = await diffusionServer.calibrate({
+  modelId: 'flux-2-klein',
+  sizes: [{ width: 768, height: 768 }],
+  steps: 4, // use your app's real step count
+  onProgress: (p) => updateBar(p.overallPercent),
+});
+
+const best = report.recommended['768x768'];
+if (best) {
+  const { label, ...flags } = best;
+  await diffusionServer.start({ modelId: 'flux-2-klein', ...flags });
+}
+```
+
+Highlights:
+
+- Progress via `onProgress` callback **and** the `'calibration-progress'` event (IPC-forwardable; monotonic `overallPercent` for progress bars)
+- Cancellable via `AbortSignal` — aborts throw a `ServerError` with `details.code === 'CALIBRATION_ABORTED'` and partial results in `details.runs`
+- Running LLM is offloaded once for the sweep and restored afterwards
+- SD3.5-Large: forced `clipOnCpu: true` combos are auto-skipped (upstream leejet/stable-diffusion.cpp#1578)
+- New exports: `DIFFUSION_CALIBRATION_DEFAULTS` plus the `DiffusionOffloadCombo`, `CalibrationSize`, `CalibrationRun`, `DiffusionCalibrationConfig` / `Progress` / `Report` types
+
+Measured on the reference machine (RTX 4060 Laptop 8 GB, Flux 2 Klein Q4_0 at 768²): the recommended combo ran **~2× faster** than the auto heuristic (17.1 s vs 33.5 s median).
+
+## See Also
+
+- [Image Generation — Offload Calibration](image-generation.md#offload-calibration) · [Resource Orchestration](resource-orchestration.md) · [Migrating 0.9 → 0.10](migration-0-9-to-0-10.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-electron",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-electron",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/gguf": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-electron",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Electron-specific library for managing local AI model servers and resources",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * to run AI models locally on desktop systems.
  *
  * @module genai-electron
- * @version 0.10.0
+ * @version 0.11.0
  * @license MIT
  *
  * @example


### PR DESCRIPTION
## Release v0.11.0

Purely additive release: the **diffusion offload calibration API** (\`diffusionServer.calibrate()\`), merged in #38.

This PR carries only the release mechanics:
- Version strings: \`package.json\` / \`package-lock.json\` / \`src/index.ts\` \`@version\` / README → **0.11.0**
- \`genai-electron-docs/migration-0-10-to-0-11.md\` (no breaking changes — nothing to migrate)
- PROGRESS.md: "Unreleased" entry promoted to the v0.11.0 release section
- Docs index: version line + migration link
- Plan file release note

After merge: tag \`v0.11.0\` → GitHub release → \`npm publish\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaKAjBh2eRECbWUcBRTL8f