### PR TITLE
release: v0.12.0 — calibrate() takes a required generation block (cfgScale fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ src/
 - **Multi-Component**: `DIFFUSION_COMPONENT_FLAGS`, `DIFFUSION_COMPONENT_ORDER`, `getModelDirectory()` - Multi-file diffusion model support
 - **Port Utilities**: `findFreePort()`, `isPortBindable()` - Free-port selection and bind testing (also `port: 'auto'` on server configs)
 - **Cancellation**: `DiffusionServerManager.cancelImageGeneration()` / `getActiveGenerationId()` - Cancel in-flight async image generation (also `DELETE /v1/images/generations/:id`)
-- **Offload Calibration**: `DiffusionServerManager.calibrate()` / `isCalibrating()`, `DIFFUSION_CALIBRATION_DEFAULTS`, `'calibration-progress'` event - Benchmark CPU-offload flag combos per machine (types: `DiffusionOffloadCombo`, `CalibrationSize`, `CalibrationRun`, `DiffusionCalibration{Config,Progress,Report}`)
+- **Offload Calibration**: `DiffusionServerManager.calibrate()` / `isCalibrating()`, `DIFFUSION_CALIBRATION_DEFAULTS`, `'calibration-progress'` event - Benchmark CPU-offload flag combos per machine. `calibrate()` requires `sizes` + a `generation` block (`steps`/`cfgScale`/`sampler`) that must mirror production — a `cfgScale` mismatch doubles the measured work and can invert the ranking (types: `DiffusionOffloadCombo`, `CalibrationSize`, `DiffusionCalibrationGeneration`, `CalibrationRun`, `DiffusionCalibration{Config,Progress,Report}`)
 - **Types**: `DiffusionComponentRole`, `DiffusionComponentInfo`, `DiffusionModelComponents`, `DiffusionComponentDownload`, `ShardInfo`, `KVCacheType`, `FlashAttentionSetting`, `LogRotationOptions`
 - **Complete list**: See `src/index.ts` for all exported utilities, types, and classes
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # genai-electron Implementation Progress
 
-> **Current Status**: v0.11.0 released — diffusion offload calibration (2026-07-04)
+> **Current Status**: v0.12.0 released — calibration mirrors production generation params (2026-07-04)
 
 ---
 
@@ -8,8 +8,46 @@
 
 - **Build:** ✅ 0 TypeScript errors
 - **Tests:** ✅ 566/566 passing (22 suites)
-- **Branch:** `main` (v0.11.0)
-- **Last Updated:** 2026-07-04 (v0.11.0 release)
+- **Branch:** `main` (v0.12.0)
+- **Last Updated:** 2026-07-04 (v0.12.0 release)
+
+---
+
+## v0.12.0: Calibration Mirrors Production Generation Params (breaking `calibrate()` change) (2026-07-04)
+
+**Problem:** `calibrate()` let the compute-shaping generation params default individually, so a
+partial call silently diverged from production. In particular `cfgScale` defaulted to *omitted →
+sd.cpp default (> 1)*, which enables classifier-free guidance = **two model passes per step**. A
+downstream app (palimpsest) benchmarked Flux Klein without passing `cfgScale`, so every calibration
+generation did ~2× the diffusion work of its real generations (`cfgScale: 1`, guidance-distilled) —
+inflating all times and **inverting the offload ranking** (offload-on measured ~16 s in the sweep
+vs ~8 s in real use; the sweep then recommended the offload-off combo). Root-caused from the app's
+own logs: identical model/size/steps/threads/sampler/flags, only sampling time doubled (10.2 s vs
+5.1 s), load/decode identical → the classifier-free-guidance signature.
+
+**Fix (breaking):** the compute-shaping params are no longer individually defaultable —
+`DiffusionCalibrationConfig` now takes them as a required unit:
+- New required `sizes: CalibrationSize[]` (was optional, defaulted to 768²) and required
+  `generation: DiffusionCalibrationGeneration` (`{ steps, cfgScale, sampler }` required, optional
+  `threads`/`batchSize`). Removed the flat `steps`/`cfgScale`/`sampler`/`threads`/`batchSize` fields.
+- New exported type `DiffusionCalibrationGeneration`.
+- `DiffusionCalibrationReport` gains `cfgScale` (methodology echo alongside `steps`/`sampler`).
+- `DIFFUSION_CALIBRATION_DEFAULTS` drops `sizes`/`steps`/`sampler` (caller-supplied now).
+
+**Migration:** wrap the old flat fields in `generation` / `sizes`, and **pass your production
+`cfgScale`** (e.g. `1` for Flux Klein / SDXL-Lightning/Turbo; 5–8 for standard models):
+`calibrate({ modelId, sizes: [...], generation: { steps, cfgScale, sampler } })`.
+
+**Files:** `src/types/images.ts`, `src/types/index.ts`, `src/index.ts`, `src/config/defaults.ts`,
+`src/managers/DiffusionServerManager.ts`, `tests/unit/diffusion-calibration.test.ts` (helper +
+`cfgScale` echo assertion), example app (`ipc-handlers`, `DiffusionServerControl`, `renderer/types/api`),
+docs (`image-generation`, `typescript-reference`, `migration-0-11-to-0-12.md`, docs index). Downstream
+palimpsest call site tracked in that repo's `ISSUE-diffusion-calibration-cfgscale.md`.
+
+**Build:** ✅ 0 TypeScript errors / 566/566 tests passing (22 suites); example app typechecks clean.
+
+**Released 2026-07-04 as v0.12.0.** Breaking change scoped to `calibrate()` (added in v0.11.0);
+see `genai-electron-docs/migration-0-11-to-0-12.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # genai-electron
 
-> **Version**: 0.11.0 | **Status**: Production Ready - LLM & Image Generation, per-machine offload calibration
+> **Version**: 0.12.0 | **Status**: Production Ready - LLM & Image Generation, per-machine offload calibration
 
 Electron-specific library for managing local AI model servers (llama.cpp, stable-diffusion.cpp). Handles platform-specific operations to run AI models locally. Complements [genai-lite](https://github.com/lacerbi/genai-lite) for API abstraction.
 

--- a/examples/electron-control-panel/main/ipc-handlers.ts
+++ b/examples/electron-control-panel/main/ipc-handlers.ts
@@ -13,6 +13,7 @@ import {
   sendImageProgress,
 } from './genai-api.js';
 import { MetadataFetchStrategy, formatErrorForUI } from 'genai-electron';
+import type { ImageSampler } from 'genai-electron';
 import { LLMService, ImageService } from 'genai-lite';
 
 /**
@@ -339,8 +340,8 @@ export function registerIpcHandlers(): void {
       _event,
       config: {
         modelId: string;
-        sizes?: { width: number; height: number }[];
-        steps?: number;
+        sizes: { width: number; height: number }[];
+        generation: { steps: number; cfgScale: number; sampler: ImageSampler };
         samples?: number;
       }
     ) => {
@@ -354,7 +355,7 @@ export function registerIpcHandlers(): void {
         const report = await diffusionServer.calibrate({
           modelId: config.modelId,
           sizes: config.sizes,
-          steps: config.steps,
+          generation: config.generation,
           samples: config.samples,
           signal: calibrationController.signal,
         });

--- a/examples/electron-control-panel/renderer/components/DiffusionServerControl.tsx
+++ b/examples/electron-control-panel/renderer/components/DiffusionServerControl.tsx
@@ -244,12 +244,13 @@ const DiffusionServerControl: React.FC = () => {
     setCalibrationPartialRuns(null);
     setCalibrationProgress(null);
     try {
-      // Benchmark at the Generate form's current size/steps (the settings that
-      // will actually be used) — everything else uses library defaults
+      // Benchmark at the Generate form's exact settings (size + the generation
+      // params that shape the compute profile) so the result reflects real use.
+      // cfgScale matters most: cfgScale > 1 doubles the diffusion work.
       const outcome = await window.api.diffusion.calibrate({
         modelId: selectedModel,
         sizes: [{ width, height }],
-        steps,
+        generation: { steps, cfgScale, sampler },
       });
       if ('aborted' in outcome) {
         setCalibrationPartialRuns(outcome.runs);

--- a/examples/electron-control-panel/renderer/types/api.ts
+++ b/examples/electron-control-panel/renderer/types/api.ts
@@ -166,8 +166,8 @@ export interface WindowAPI {
     cancel: () => Promise<{ cancelled: boolean }>;
     calibrate: (config: {
       modelId: string;
-      sizes?: CalibrationSize[];
-      steps?: number;
+      sizes: CalibrationSize[];
+      generation: { steps: number; cfgScale: number; sampler: ImageSampler };
       samples?: number;
     }) => Promise<CalibrationOutcome>;
     calibrateCancel: () => Promise<{ cancelling: boolean }>;

--- a/genai-electron-docs/image-generation.md
+++ b/genai-electron-docs/image-generation.md
@@ -324,9 +324,17 @@ calibrate(config: DiffusionCalibrationConfig): Promise<DiffusionCalibrationRepor
 
 Runs the sweep and returns a report. The caller persists/applies the recommendation — the library does not store it.
 
-**Config:** `modelId` (required), `sizes` (default `[{ width: 768, height: 768 }]` — pass your app's real sizes), `combos` (default: curated labeled set in `DIFFUSION_CALIBRATION_DEFAULTS`: `auto`, `clip-gpu`, `clip-gpu+offload`, `offload`, `all-resident`, `max-savings`), `steps` (default 4 — **use your real step count**, offload cost scales with steps), `cfgScale`, `sampler` (`'euler'`), `seed` (42, fixed so every combo does identical work), `prompt`, `samples` (2 timed samples per combo × size, after 1 discarded warmup per combo), `threads`/`batchSize` (match your production config), `onProgress`, `signal`.
+**Config:**
+- `modelId` (**required**).
+- `sizes` (**required**) — the image size(s) your app generates at (`{ width, height }`, positive multiples of 64). Compute scales with area, so the fastest combo can differ by size.
+- `generation` (**required**) — the production generation parameters the sweep must mirror, as a unit: `steps`, `cfgScale`, `sampler` (all required) plus optional `threads`/`batchSize`. See the ⚠️ below.
+- `combos` (default: curated labeled set in `DIFFUSION_CALIBRATION_DEFAULTS`: `auto`, `clip-gpu`, `clip-gpu+offload`, `offload`, `all-resident`, `max-savings`).
+- `samples` (default 2 timed samples per combo × size, after 1 discarded warmup per combo).
+- `seed` (default 42, fixed so every combo does identical work), `prompt` (neutral benchmark; does not affect timing), `onProgress`, `signal`.
 
-Default sweep cost: 6 combos × (1 warmup + 2 samples) = 18 generations — typically a few minutes.
+> ⚠️ **`generation` must match what you generate with in production** — these parameters define the *compute profile* the sweep measures, and a mismatch makes the benchmark rank the combos wrong. In particular **`cfgScale`**: a value > 1 enables classifier-free guidance, which runs **two model passes per step (~2× the diffusion cost)** and can flip which offload combo wins. Guidance-distilled models (Flux Klein, SDXL-Lightning/Turbo) run at `cfgScale: 1`; standard models are typically 5–8. (`steps`, `cfgScale`, `sampler`, and `sizes` have no library defaults precisely so calibration can never *silently* diverge from production.)
+
+Default sweep cost: 6 combos × (1 warmup + 2 samples) = 18 generations per size — typically a few minutes.
 
 **Contract:**
 - The server must be **stopped** and is left stopped. `start()` throws while calibrating; `isCalibrating()` exposes the state (`getInfo().busy` may briefly read `true` while `status` stays `'stopped'` — harmless).
@@ -339,8 +347,13 @@ Default sweep cost: 6 combos × (1 warmup + 2 samples) = 18 generations — typi
 ```typescript
 const report = await diffusionServer.calibrate({
   modelId: 'flux-2-klein',
-  sizes: [{ width: 768, height: 768 }, { width: 512, height: 1024 }], // the app's real sizes
-  steps: 4,                                                            // the app's quality preset
+  sizes: [{ width: 768, height: 768 }, { width: 512, height: 1024 }], // your app's real sizes
+  generation: {
+    steps: 4, // your app's quality preset
+    cfgScale: 1, // MUST match production — Flux Klein is guidance-distilled (cfg 1)
+    sampler: 'euler',
+    // threads / batchSize: pass your production values here if you set them
+  },
   onProgress: (p) => updateBar(p.overallPercent, p.phase, p.combo?.label),
 });
 
@@ -379,7 +392,7 @@ Pass an `AbortSignal`. On abort the in-flight generation is killed and `calibrat
 const controller = new AbortController();
 cancelButton.onclick = () => controller.abort();
 try {
-  await diffusionServer.calibrate({ modelId, signal: controller.signal });
+  await diffusionServer.calibrate({ modelId, sizes, generation, signal: controller.signal });
 } catch (error) {
   if (error.details?.code === 'CALIBRATION_ABORTED') {
     console.log('Aborted; partial results:', error.details.runs);
@@ -389,7 +402,7 @@ try {
 
 ### Caveats
 
-- **Calibrate with your real settings.** `offloadToCpu` overhead scales with step count and larger sizes shift the optimum (hence per-size recommendations). The default `steps: 4` suits distilled models (SDXL-Turbo, Flux Klein).
+- **Calibrate with your real settings** (`generation` + `sizes`). `offloadToCpu` overhead scales with step count, larger sizes shift the optimum (hence per-size recommendations), and — most impactfully — `cfgScale > 1` doubles the diffusion work (two passes/step) and can invert the ranking. The report echoes `steps`/`cfgScale`/`sampler`/`samples` so a persisted recommendation records the exact methodology it was measured under.
 - **Sizes must be positive multiples of 64** (sd.cpp constraint; validated up-front).
 - **SD3.5-Large:** combos forcing `clipOnCpu: true` are skipped automatically (garbled output upstream — leejet/stable-diffusion.cpp#1578) and listed in `report.skippedCombos`. Auto-detection may still resolve `clipOnCpu` on for auto combos on low-VRAM machines — prefer explicit `clipOnCpu: false` combos for this model family.
 - **Timing noise:** thermal throttling and background load perturb results; the raw per-sample totals are kept in `runs[].samplesMs`. `timeTakenMs` is the median (with `samples: 2`, the mean of both).

--- a/genai-electron-docs/index.md
+++ b/genai-electron-docs/index.md
@@ -26,6 +26,7 @@ Complete documentation for genai-electron - An Electron-specific library for man
 - **[Troubleshooting](troubleshooting.md)** - Common issues, error codes, FAQ
 
 ### Migration
+- **[Migrating from v0.11.x to v0.12.0](migration-0-11-to-0-12.md)** - `calibrate()` now takes a required `generation` block (`steps`/`cfgScale`/`sampler`) so it mirrors production; pass your real `cfgScale`
 - **[Migrating from v0.10.x to v0.11.0](migration-0-10-to-0-11.md)** - Offload calibration (`calibrate()`); purely additive, nothing to migrate
 - **[Migrating from v0.9.x to v0.10.0](migration-0-9-to-0-10.md)** - stable-diffusion.cpp master-746 bump; CPU-offload flags now auto-detected on CUDA too
 - **[Migrating from v0.8.x to v0.9.0](migration-0-8-to-0-9.md)** - Structured `'binary-progress'` event for provisioning UIs

--- a/genai-electron-docs/migration-0-11-to-0-12.md
+++ b/genai-electron-docs/migration-0-11-to-0-12.md
@@ -1,0 +1,67 @@
+# Migrating from v0.11.x to v0.12.0
+
+v0.12.0 has **one breaking change**, scoped entirely to `diffusionServer.calibrate()` (added in v0.11.0). Everything else — LLM server, image generation, resource orchestration, binaries — is unchanged. No binary re-download.
+
+If you do not call `calibrate()`, there is nothing to migrate.
+
+## Breaking change: `calibrate()` now takes a required `generation` block
+
+The compute-shaping parameters (`steps`, `cfgScale`, `sampler`, and image `sizes`) can no longer be defaulted individually. They must be supplied, as a unit, so calibration always measures the **same work your app does in production**.
+
+### Why
+
+In v0.11.0 these were optional, and `cfgScale` in particular defaulted to *omitted → sd.cpp's built-in default_ (> 1)*. A `cfgScale > 1` enables classifier-free guidance, which runs **two model passes per sampling step (~2× the diffusion cost)**. If your real generations run at a different CFG (guidance-distilled models like Flux Klein, SDXL-Lightning/Turbo run at `cfgScale: 1`), the sweep benchmarked twice the work of production — inflating all times and, because the extra pass loads the offload path, **flipping which offload combo it recommends**. Making the generation parameters required (no silent defaults) closes that gap.
+
+### Before (v0.11.x)
+
+```typescript
+const report = await diffusionServer.calibrate({
+  modelId: 'flux-2-klein',
+  sizes: [{ width: 768, height: 768 }], // was optional (defaulted to 768²)
+  steps: 4,                              // was optional (defaulted to 4)
+  // cfgScale omitted → sd.cpp default (> 1) → 2× the real work!
+  // sampler omitted → 'euler'
+});
+```
+
+### After (v0.12.0)
+
+```typescript
+const report = await diffusionServer.calibrate({
+  modelId: 'flux-2-klein',
+  sizes: [{ width: 768, height: 768 }], // required
+  generation: {                          // required — mirror production
+    steps: 4,
+    cfgScale: 1,     // REQUIRED — pass the same CFG you generate with
+    sampler: 'euler',
+    // threads / batchSize: optional; pass your production values if you set them
+  },
+  onProgress: (p) => updateBar(p.overallPercent),
+});
+```
+
+### Mechanical mapping
+
+| v0.11.x (flat) | v0.12.0 |
+|---|---|
+| `steps` | `generation.steps` (required) |
+| `cfgScale` | `generation.cfgScale` (**required** — no default) |
+| `sampler` | `generation.sampler` (required) |
+| `threads` | `generation.threads` (optional) |
+| `batchSize` | `generation.batchSize` (optional) |
+| `sizes` (optional) | `sizes` (**required**) |
+| `combos`, `samples`, `seed`, `prompt`, `onProgress`, `signal` | unchanged |
+
+> **Pass your real `cfgScale`.** `1` for guidance-distilled models (Flux Klein, SDXL-Lightning, SDXL-Turbo); typically `5`–`8` for standard models. This is the single parameter most likely to change the recommendation if it's wrong.
+
+## Also new
+
+- **Type `DiffusionCalibrationGeneration`** is exported (the `generation` block).
+- **`DiffusionCalibrationReport` gains `cfgScale`** — the methodology echo now records `steps`, `cfgScale`, `sampler`, and `samples`, so a persisted recommendation captures the exact CFG it was measured under.
+- **`DIFFUSION_CALIBRATION_DEFAULTS`** no longer carries `sizes` / `steps` / `sampler` (those are caller-supplied now); `combos`, `samples`, `seed`, `prompt`, tie-tolerance, and the pattern sets still have defaults.
+
+## See Also
+
+- [Image Generation — Offload Calibration](image-generation.md#offload-calibration) (see the ⚠️ `cfgScale` callout)
+- [TypeScript Reference — `DiffusionCalibrationGeneration`](typescript-reference.md#diffusioncalibrationgeneration)
+- [Migrating 0.10 → 0.11](migration-0-10-to-0-11.md)

--- a/genai-electron-docs/typescript-reference.md
+++ b/genai-electron-docs/typescript-reference.md
@@ -569,23 +569,34 @@ interface CalibrationSize {
 }
 ```
 
+### DiffusionCalibrationGeneration
+
+The production generation parameters an offload-calibration sweep runs under. Required as a unit (no defaults) so calibration measures the same compute profile as your real generations — a mismatch, `cfgScale` above all, can rank the combos wrong.
+
+```typescript
+interface DiffusionCalibrationGeneration {
+  steps: number;      // match production (diffusion/offload cost scales with steps)
+  cfgScale: number;   // match production — cfgScale > 1 = 2 model passes/step (~2x cost),
+                      //   can flip the winner. Distilled models (Flux Klein, Turbo) run at 1.
+  sampler: ImageSampler; // match production (per-step cost varies by sampler)
+  threads?: number;   // match production -t (offload is CPU-sensitive); omitted = sd.cpp default
+  batchSize?: number; // match production -b; omitted = sd.cpp default
+}
+```
+
 ### DiffusionCalibrationConfig
 
-Configuration for `diffusionServer.calibrate()`. Prefer your app's real `sizes`/`steps` — the optimum shifts with both.
+Configuration for `diffusionServer.calibrate()`. `sizes` and `generation` are required and must reflect production.
 
 ```typescript
 interface DiffusionCalibrationConfig {
   modelId: string;
-  sizes?: CalibrationSize[];          // default: [{ width: 768, height: 768 }]
+  sizes: CalibrationSize[];           // your app's real size(s); multiples of 64
+  generation: DiffusionCalibrationGeneration; // production params the sweep mirrors
   combos?: DiffusionOffloadCombo[];   // default: DIFFUSION_CALIBRATION_DEFAULTS.combos
-  steps?: number;                     // default: 4
-  cfgScale?: number;                  // default: omitted (sd.cpp default)
-  sampler?: ImageSampler;             // default: 'euler'
   seed?: number;                      // default: 42 (fixed → identical work per combo)
-  prompt?: string;                    // default: neutral built-in prompt
+  prompt?: string;                    // default: neutral built-in prompt (does not affect timing)
   samples?: number;                   // default: 2 (timed samples per combo × size)
-  threads?: number;                   // passthrough (match production -t)
-  batchSize?: number;                 // passthrough (match production -b)
   onProgress?: (progress: DiffusionCalibrationProgress) => void;
   signal?: AbortSignal;               // abort → details.code === 'CALIBRATION_ABORTED'
 }
@@ -645,6 +656,7 @@ interface DiffusionCalibrationReport {
   };
   modelId: string;
   steps: number;                      // methodology echo (persistence keying)
+  cfgScale: number;                   // methodology echo
   sampler: ImageSampler;
   samples: number;
   runs: CalibrationRun[];
@@ -877,16 +889,13 @@ const DIFFUSION_COMPONENT_ORDER: readonly DiffusionComponentRole[];
 
 ### DIFFUSION_CALIBRATION_DEFAULTS
 
-Defaults for [offload calibration](image-generation.md#offload-calibration): the curated labeled combo set (`auto`, `clip-gpu`, `clip-gpu+offload`, `offload`, `all-resident`, `max-savings`), default sizes/steps/samples/seed/sampler/prompt, the 5% tie tolerance, the SD3.5-Large id/name pattern, and the OOM stderr patterns.
+Defaults for [offload calibration](image-generation.md#offload-calibration): the curated labeled combo set (`auto`, `clip-gpu`, `clip-gpu+offload`, `offload`, `all-resident`, `max-savings`), default samples/seed/prompt, the 5% tie tolerance, the SD3.5-Large id/name pattern, and the OOM stderr patterns. (`sizes`/`steps`/`cfgScale`/`sampler` are intentionally **not** defaulted — the caller supplies them via `sizes` / `generation` so calibration mirrors production.)
 
 ```typescript
 const DIFFUSION_CALIBRATION_DEFAULTS: {
-  readonly sizes: readonly CalibrationSize[];       // [{ width: 768, height: 768 }]
   readonly combos: readonly DiffusionOffloadCombo[];
-  readonly steps: number;                           // 4
   readonly samples: number;                         // 2
   readonly seed: number;                            // 42
-  readonly sampler: ImageSampler;                   // 'euler'
   readonly prompt: string;
   readonly tieTolerancePct: number;                 // 5
   readonly sd35LargePattern: RegExp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-electron",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-electron",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/gguf": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-electron",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Electron-specific library for managing local AI model servers and resources",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -3,12 +3,7 @@
  * @module config/defaults
  */
 
-import type {
-  CalibrationSize,
-  DiffusionComponentRole,
-  DiffusionOffloadCombo,
-  ImageSampler,
-} from '../types/index.js';
+import type { DiffusionComponentRole, DiffusionOffloadCombo } from '../types/index.js';
 
 /**
  * Default ports for different server types
@@ -290,12 +285,9 @@ export const DIFFUSION_VRAM_THRESHOLDS = {
  * Combo labels are surfaced by progress UIs and persisted recommendations.
  */
 export const DIFFUSION_CALIBRATION_DEFAULTS: {
-  readonly sizes: readonly CalibrationSize[];
   readonly combos: readonly DiffusionOffloadCombo[];
-  readonly steps: number;
   readonly samples: number;
   readonly seed: number;
-  readonly sampler: ImageSampler;
   readonly prompt: string;
   /** Runs within this % of the fastest prefer fewer forced flags (robustness tie-break) */
   readonly tieTolerancePct: number;
@@ -304,7 +296,9 @@ export const DIFFUSION_CALIBRATION_DEFAULTS: {
   /** stderr/message patterns classifying a failed generation as out-of-memory */
   readonly oomPatterns: readonly RegExp[];
 } = {
-  sizes: [{ width: 768, height: 768 }],
+  // steps/cfgScale/sampler/sizes are NOT defaulted — the caller must pass them
+  // (via DiffusionCalibrationConfig.generation / .sizes) so the sweep measures the
+  // same compute profile as production. See DiffusionCalibrationGeneration.
   combos: [
     { label: 'auto' },
     { label: 'clip-gpu', clipOnCpu: false },
@@ -313,10 +307,8 @@ export const DIFFUSION_CALIBRATION_DEFAULTS: {
     { label: 'all-resident', clipOnCpu: false, vaeOnCpu: false, offloadToCpu: false },
     { label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true },
   ],
-  steps: 4,
   samples: 2,
   seed: 42,
-  sampler: 'euler',
   prompt: 'a photograph of a lighthouse on a rocky coast at sunset, detailed',
   tieTolerancePct: 5,
   sd35LargePattern: /(?:sd|stable[-_.\s]?diffusion)[-_.\s]?3[-_.\s]?5.*?large/i,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * to run AI models locally on desktop systems.
  *
  * @module genai-electron
- * @version 0.11.0
+ * @version 0.12.0
  * @license MIT
  *
  * @example
@@ -306,6 +306,7 @@ export type {
   GenerationState,
   DiffusionOffloadCombo,
   CalibrationSize,
+  DiffusionCalibrationGeneration,
   DiffusionCalibrationConfig,
   DiffusionCalibrationProgress,
   CalibrationRun,

--- a/src/managers/DiffusionServerManager.ts
+++ b/src/managers/DiffusionServerManager.ts
@@ -466,7 +466,13 @@ export class DiffusionServerManager extends ServerManager {
     }
 
     const defaults = DIFFUSION_CALIBRATION_DEFAULTS;
-    const sizes = config.sizes && config.sizes.length > 0 ? config.sizes : [...defaults.sizes];
+    const sizes = config.sizes;
+    if (!sizes || sizes.length === 0) {
+      throw new ServerError('Calibration requires at least one size in config.sizes', {
+        suggestion:
+          'Pass the size(s) your app generates at, e.g. sizes: [{ width: 768, height: 768 }]',
+      });
+    }
     for (const size of sizes) {
       if (
         !Number.isInteger(size.width) ||
@@ -483,9 +489,10 @@ export class DiffusionServerManager extends ServerManager {
       }
     }
     const samples = Math.max(1, Math.floor(config.samples ?? defaults.samples));
-    const steps = config.steps ?? defaults.steps;
+    const steps = config.generation.steps;
+    const cfgScale = config.generation.cfgScale;
     const seed = config.seed ?? defaults.seed;
-    const sampler = config.sampler ?? defaults.sampler;
+    const sampler = config.generation.sampler;
     const prompt = config.prompt ?? defaults.prompt;
 
     const runs: CalibrationRun[] = [];
@@ -624,11 +631,11 @@ export class DiffusionServerManager extends ServerManager {
         throw this.calibrationAbortError(runs);
       }
       const syntheticConfig: DiffusionServerConfig = { modelId: config.modelId };
-      if (config.threads !== undefined) {
-        syntheticConfig.threads = config.threads;
+      if (config.generation.threads !== undefined) {
+        syntheticConfig.threads = config.generation.threads;
       }
-      if (config.batchSize !== undefined) {
-        syntheticConfig.batchSize = config.batchSize;
+      if (config.generation.batchSize !== undefined) {
+        syntheticConfig.batchSize = config.generation.batchSize;
       }
       this._config = syntheticConfig as unknown as typeof this._config;
 
@@ -665,7 +672,7 @@ export class DiffusionServerManager extends ServerManager {
             prompt,
             size: sizes[0]!,
             steps,
-            cfgScale: config.cfgScale,
+            cfgScale,
             seed,
             sampler,
             combo,
@@ -719,7 +726,7 @@ export class DiffusionServerManager extends ServerManager {
                   prompt,
                   size,
                   steps,
-                  cfgScale: config.cfgScale,
+                  cfgScale,
                   seed,
                   sampler,
                   combo,
@@ -815,6 +822,7 @@ export class DiffusionServerManager extends ServerManager {
         machine,
         modelId: config.modelId,
         steps,
+        cfgScale,
         sampler,
         samples,
         runs,
@@ -897,7 +905,7 @@ export class DiffusionServerManager extends ServerManager {
     prompt: string;
     size: CalibrationSize;
     steps: number;
-    cfgScale?: number;
+    cfgScale: number;
     seed: number;
     sampler: ImageSampler;
     combo: DiffusionOffloadCombo;
@@ -908,6 +916,7 @@ export class DiffusionServerManager extends ServerManager {
       width: params.size.width,
       height: params.size.height,
       steps: params.steps,
+      cfgScale: params.cfgScale,
       seed: params.seed,
       sampler: params.sampler,
       onProgress: (_currentStep, _totalSteps, _stage, percentage) => {
@@ -916,9 +925,6 @@ export class DiffusionServerManager extends ServerManager {
         }
       },
     };
-    if (params.cfgScale !== undefined) {
-      genConfig.cfgScale = params.cfgScale;
-    }
     return this.executeImageGeneration(genConfig, params.combo);
   }
 

--- a/src/types/images.ts
+++ b/src/types/images.ts
@@ -306,44 +306,77 @@ export interface CalibrationSize {
 }
 
 /**
+ * Generation parameters an offload-calibration sweep runs under.
+ *
+ * These define the *compute profile* the sweep measures, so they MUST mirror the
+ * settings the app uses in production — otherwise the benchmark does different work
+ * than real generations and can rank the offload combos wrong. The sweep runs these
+ * verbatim for every combo and varies only the offload flags.
+ *
+ * Provided as a required unit (rather than individually-defaulting fields) so
+ * calibration can never *silently* diverge from production on any of these axes.
+ */
+export interface DiffusionCalibrationGeneration {
+  /**
+   * Inference steps — match production. Diffusion (and offload-streaming) cost scales
+   * roughly linearly with steps.
+   */
+  steps: number;
+
+  /**
+   * Guidance scale — match production. A cfgScale > 1 enables classifier-free guidance,
+   * which runs TWO model passes per step (~2x the diffusion cost) and can flip which
+   * offload combo wins. Guidance-distilled models (Flux Klein, SDXL-Lightning, Turbo)
+   * run at 1; standard models are typically 5-8. Required (no default) precisely because
+   * omitting it silently doubled the measured work in earlier versions.
+   */
+  cfgScale: number;
+
+  /** Sampler algorithm — match production (per-step cost varies by sampler) */
+  sampler: ImageSampler;
+
+  /**
+   * CPU threads (sd.cpp `-t`) — match production. Offload combos are CPU-sensitive, so a
+   * thread-count mismatch skews their timings. Omitted = sd.cpp default.
+   */
+  threads?: number;
+
+  /** Batch size (sd.cpp `-b`) — match production. Omitted = sd.cpp default */
+  batchSize?: number;
+}
+
+/**
  * Configuration for DiffusionServerManager.calibrate()
  */
 export interface DiffusionCalibrationConfig {
   /** Diffusion model ID to calibrate */
   modelId: string;
 
-  /** Sizes to benchmark (default: [{ width: 768, height: 768 }]). Pass your app's real sizes */
-  sizes?: CalibrationSize[];
+  /**
+   * Sizes to benchmark — include the size(s) your app actually generates at. Compute
+   * scales with area, so the fastest combo can differ by size. Each width/height must
+   * be a positive multiple of 64.
+   */
+  sizes: CalibrationSize[];
+
+  /**
+   * Generation parameters the sweep must mirror from production (steps, cfgScale,
+   * sampler, threads, batchSize). Required as a unit so the benchmark measures the same
+   * work your real generations do — see {@link DiffusionCalibrationGeneration}.
+   */
+  generation: DiffusionCalibrationGeneration;
 
   /** Offload combos to benchmark (default: curated set in DIFFUSION_CALIBRATION_DEFAULTS) */
   combos?: DiffusionOffloadCombo[];
 
-  /**
-   * Inference steps per generation (default: 4).
-   * Offload cost scales with steps — prefer your app's real step count.
-   */
-  steps?: number;
-
-  /** Guidance scale (default: omitted, uses the sd.cpp default) */
-  cfgScale?: number;
-
-  /** Sampler algorithm (default: 'euler') */
-  sampler?: ImageSampler;
+  /** Timed samples per (combo, size), after 1 discarded warmup per combo (default: 2) */
+  samples?: number;
 
   /** Fixed seed so every combo does identical work (default: 42) */
   seed?: number;
 
-  /** Benchmark prompt (default: neutral built-in prompt) */
+  /** Benchmark prompt — does not affect timing (default: neutral built-in prompt) */
   prompt?: string;
-
-  /** Timed samples per (combo, size), after 1 discarded warmup per combo (default: 2) */
-  samples?: number;
-
-  /** CPU threads passthrough — match your production config (default: omitted) */
-  threads?: number;
-
-  /** Batch size passthrough — match your production config (default: omitted) */
-  batchSize?: number;
 
   /** Progress callback (the same payload is also emitted as 'calibration-progress' events) */
   onProgress?: (progress: DiffusionCalibrationProgress) => void;
@@ -448,6 +481,9 @@ export interface DiffusionCalibrationReport {
 
   /** Inference steps used per generation (methodology echo for persistence keying) */
   steps: number;
+
+  /** Guidance scale used per generation (methodology echo) */
+  cfgScale: number;
 
   /** Sampler used (methodology echo) */
   sampler: ImageSampler;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,7 @@ export type {
   GenerationState,
   DiffusionOffloadCombo,
   CalibrationSize,
+  DiffusionCalibrationGeneration,
   DiffusionCalibrationConfig,
   DiffusionCalibrationProgress,
   CalibrationRun,

--- a/tests/unit/diffusion-calibration.test.ts
+++ b/tests/unit/diffusion-calibration.test.ts
@@ -13,7 +13,10 @@ import { jest } from '@jest/globals';
 import { EventEmitter } from 'events';
 import type {
   CalibrationRun,
+  DiffusionCalibrationConfig,
+  DiffusionCalibrationGeneration,
   DiffusionCalibrationProgress,
+  DiffusionCalibrationReport,
   DiffusionServerConfig,
   ModelInfo,
 } from '../../src/types/index.js';
@@ -216,6 +219,30 @@ describe('DiffusionServerManager calibration', () => {
     port: 8081,
   };
 
+  // Required generation params (mirror production). Tests default to a distilled
+  // cfg=1 profile; assertions that care about steps/sampler rely on these.
+  const BASE_GEN: DiffusionCalibrationGeneration = { steps: 4, cfgScale: 1, sampler: 'euler' };
+  const DEFAULT_SIZES = [{ width: 768, height: 768 }];
+
+  /**
+   * Invoke calibrate() with the now-required `sizes` + `generation` filled in.
+   * Overrides win; a partial `generation` is merged onto BASE_GEN.
+   */
+  const runCalibrate = (
+    target: InstanceType<typeof DiffusionServerManager>,
+    overrides: Omit<Partial<DiffusionCalibrationConfig>, 'generation'> & {
+      generation?: Partial<DiffusionCalibrationGeneration>;
+    } = {}
+  ): Promise<DiffusionCalibrationReport> => {
+    const { generation, sizes, modelId, ...rest } = overrides;
+    return target.calibrate({
+      modelId: modelId ?? 'sdxl-turbo',
+      sizes: sizes ?? DEFAULT_SIZES,
+      generation: { ...BASE_GEN, ...generation },
+      ...rest,
+    });
+  };
+
   /** Args of every spawned generation, in order */
   let spawnCalls: string[][] = [];
   /** Per-spawn options handles (for the kill → exit wiring) */
@@ -384,7 +411,7 @@ describe('DiffusionServerManager calibration', () => {
     it('throws if the server is running', async () => {
       await diffusionServer.start(mockServerConfig);
 
-      await expect(diffusionServer.calibrate({ modelId: 'sdxl-turbo' })).rejects.toThrow(
+      await expect(runCalibrate(diffusionServer, { modelId: 'sdxl-turbo' })).rejects.toThrow(
         /Cannot calibrate while the server is running/
       );
 
@@ -393,7 +420,7 @@ describe('DiffusionServerManager calibration', () => {
 
     it('rejects invalid sizes (non-multiple of 64) before any spawn', async () => {
       await expect(
-        diffusionServer.calibrate({
+        runCalibrate(diffusionServer, {
           modelId: 'sdxl-turbo',
           sizes: [{ width: 500, height: 512 }],
         })
@@ -406,7 +433,7 @@ describe('DiffusionServerManager calibration', () => {
       controller.abort();
 
       try {
-        await diffusionServer.calibrate({ modelId: 'sdxl-turbo', signal: controller.signal });
+        await runCalibrate(diffusionServer, { modelId: 'sdxl-turbo', signal: controller.signal });
         throw new Error('Should have thrown');
       } catch (error: any) {
         expect(error.code).toBe('SERVER_ERROR'); // top-level code is generic
@@ -419,7 +446,7 @@ describe('DiffusionServerManager calibration', () => {
 
     it('blocks start() while a calibration is in flight', async () => {
       let startRejection: Promise<void> | undefined;
-      const calibratePromise = diffusionServer.calibrate({
+      const calibratePromise = runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         onProgress: (p) => {
@@ -441,13 +468,13 @@ describe('DiffusionServerManager calibration', () => {
 
     it('rejects a second calibrate() while one is in flight', async () => {
       let secondRejection: Promise<void> | undefined;
-      const calibratePromise = diffusionServer.calibrate({
+      const calibratePromise = runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         onProgress: (p) => {
           if (p.phase === 'warmup' && !secondRejection) {
             secondRejection = expect(
-              diffusionServer.calibrate({ modelId: 'sdxl-turbo' })
+              runCalibrate(diffusionServer, { modelId: 'sdxl-turbo' })
             ).rejects.toThrow(/already in progress/);
           }
         },
@@ -463,14 +490,13 @@ describe('DiffusionServerManager calibration', () => {
 
   describe('sweep structure and per-run flag resolution', () => {
     it('spawns combos × (warmup + samples × sizes) and applies per-combo flags', async () => {
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         sizes: [
           { width: 768, height: 768 },
           { width: 512, height: 1024 },
         ],
         samples: 1,
-        steps: 4,
         combos: [
           { label: 'clip-gpu', clipOnCpu: false },
           { label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true },
@@ -526,6 +552,7 @@ describe('DiffusionServerManager calibration', () => {
       expect(report.recommended['768x768']).toBeDefined();
       expect(report.recommended['512x1024']).toBeDefined();
       expect(report.steps).toBe(4);
+      expect(report.cfgScale).toBe(1);
       expect(report.sampler).toBe('euler');
       expect(report.samples).toBe(1);
       expect(report.modelId).toBe('sdxl-turbo');
@@ -538,7 +565,7 @@ describe('DiffusionServerManager calibration', () => {
     });
 
     it('lets auto-detection resolve omitted flags (auto combo carries resolved values)', async () => {
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [{ label: 'auto' }],
@@ -577,10 +604,9 @@ describe('DiffusionServerManager calibration', () => {
       spawnScript = () => ({ stdout: [...SD_STDOUT] });
       const progressEvents: DiffusionCalibrationProgress[] = [];
 
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 2,
-        steps: 4,
         combos: [{ label: 'auto' }],
         onProgress: (p) => progressEvents.push(p),
       });
@@ -617,7 +643,7 @@ describe('DiffusionServerManager calibration', () => {
     });
 
     it('hands back per-sweep combo copies, never the module default objects', async () => {
-      const report = await diffusionServer.calibrate({ modelId: 'sdxl-turbo', samples: 1 });
+      const report = await runCalibrate(diffusionServer, { modelId: 'sdxl-turbo', samples: 1 });
 
       // Default sweep: 6 combos × (1 warmup + 1 sample × 1 size) = 12 generations
       expect(spawnCalls).toHaveLength(12);
@@ -636,7 +662,7 @@ describe('DiffusionServerManager calibration', () => {
           ? { exitCode: 1, stderr: ['ggml_cuda_host_malloc: CUDA error: out of memory'] }
           : undefined;
 
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [
@@ -663,7 +689,7 @@ describe('DiffusionServerManager calibration', () => {
       spawnScript = (index) =>
         index === 2 ? { exitCode: 1, stderr: ['some unrelated failure'] } : undefined;
 
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 2,
         combos: [{ label: 'auto' }],
@@ -683,7 +709,7 @@ describe('DiffusionServerManager calibration', () => {
       spawnScript = (index) =>
         index === 0 ? { exitCode: 1, stderr: ['cudaMalloc failed: out of memory'] } : undefined;
 
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         sizes: [
           { width: 768, height: 768 },
@@ -715,7 +741,7 @@ describe('DiffusionServerManager calibration', () => {
         eventPayloads.push(p)
       );
 
-      await diffusionServer.calibrate({
+      await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [{ label: 'auto' }, { label: 'clip-gpu', clipOnCpu: false }],
@@ -754,7 +780,7 @@ describe('DiffusionServerManager calibration', () => {
         throw new Error('listener boom');
       });
 
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [{ label: 'auto' }],
@@ -773,7 +799,7 @@ describe('DiffusionServerManager calibration', () => {
       const controller = new AbortController();
 
       try {
-        await diffusionServer.calibrate({
+        await runCalibrate(diffusionServer, {
           modelId: 'sdxl-turbo',
           samples: 1,
           combos: [{ label: 'auto' }, { label: 'clip-gpu', clipOnCpu: false }],
@@ -796,7 +822,7 @@ describe('DiffusionServerManager calibration', () => {
 
       expect(diffusionServer.isCalibrating()).toBe(false);
       // A fresh calibrate works afterwards (state fully torn down)
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [{ label: 'auto' }],
@@ -816,7 +842,7 @@ describe('DiffusionServerManager calibration', () => {
       };
 
       try {
-        await diffusionServer.calibrate({
+        await runCalibrate(diffusionServer, {
           modelId: 'sdxl-turbo',
           samples: 1,
           combos: [{ label: 'auto' }],
@@ -841,7 +867,7 @@ describe('DiffusionServerManager calibration', () => {
         name: 'Stable Diffusion 3.5 Large',
       });
 
-      const report = await diffusionServer.calibrate({
+      const report = await runCalibrate(diffusionServer, {
         modelId: 'sd3.5-large-q4',
         samples: 1,
       });
@@ -880,7 +906,7 @@ describe('DiffusionServerManager calibration', () => {
       );
       const phases: string[] = [];
 
-      const report = await server.calibrate({
+      const report = await runCalibrate(server, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [{ label: 'auto' }],
@@ -908,7 +934,7 @@ describe('DiffusionServerManager calibration', () => {
       await diffusionServer.stop();
       const configBefore = diffusionServer.getConfig();
 
-      await diffusionServer.calibrate({
+      await runCalibrate(diffusionServer, {
         modelId: 'sdxl-turbo',
         samples: 1,
         combos: [{ label: 'max-savings', clipOnCpu: true, vaeOnCpu: true, offloadToCpu: true }],


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `diffusionServer.calibrate()` (added in v0.11.0): it recommended a **slower** offload configuration than the one that is actually fastest in production, because it benchmarked ~2× the diffusion work of a real generation.

**Root cause:** `cfgScale` was optional and defaulted to *omitted → sd.cpp's built-in default (> 1)*, which enables classifier-free guidance = **two model passes per sampling step**. Guidance-distilled models (Flux Klein, SDXL-Lightning/Turbo) generate at `cfgScale: 1` (one pass), so a calibration that omitted `cfgScale` did double the work — inflating all times and, because the extra pass loads the offload path, **inverting which combo wins**.

Confirmed on the reference machine from the app's own logs: identical model / size / steps / threads / sampler / flags, only **sampling time doubled** (10.2 s vs 5.1 s), load and decode identical → the classifier-free-guidance signature. Reproduced by re-running the exact command with and without `--cfg-scale 1`.

## The fix (breaking, scoped to `calibrate()`)

The compute-shaping parameters can no longer default individually — they're supplied as a unit so calibration always mirrors production:

```ts
// BEFORE (0.11) — flat, each optional; cfgScale defaulted to sd.cpp's (>1)
calibrate({ modelId, sizes?, steps?, cfgScale?, sampler?, threads?, batchSize?, ... })

// AFTER (0.12) — sizes + generation required
calibrate({
  modelId,
  sizes: [{ width, height }],                    // required
  generation: { steps, cfgScale, sampler,        // steps/cfgScale/sampler required
                threads?, batchSize? },
  combos?, samples?, seed?, prompt?, onProgress?, signal?,
})
```

- New exported type **`DiffusionCalibrationGeneration`**.
- **`DiffusionCalibrationReport` gains `cfgScale`** (methodology echo).
- `DIFFUSION_CALIBRATION_DEFAULTS` drops `sizes`/`steps`/`sampler` (caller-supplied now).
- `steps`/`cfgScale`/`sampler`/`sizes` have **no library defaults** — omitting any is a compile error, by design, so this class of silent mismatch can't recur.

## Release contents (v0.11.0 → v0.12.0)

- Version bump: `package.json` (+ lock), `src/index.ts` `@version`, `README.md`.
- New migration guide: `genai-electron-docs/migration-0-11-to-0-12.md` (+ docs index link).
- `PROGRESS.md` v0.12.0 entry; `CLAUDE.md` Key Exports note.
- Docs: `image-generation.md` (Offload Calibration + ⚠️ cfgScale callout), `typescript-reference.md`.
- Example app: Calibrate button now benchmarks the Generate form's exact `steps`/`cfgScale`/`sampler`.
- Tests: `diffusion-calibration.test.ts` updated to the new shape + a `report.cfgScale` echo assertion.

## Verification

- ✅ `npm run build` — 0 TypeScript errors
- ✅ `npm test` — 566/566 (22 suites)
- ✅ `npm run lint` — 0 errors (62 pre-existing warnings)
- ✅ `npm run format:check` — clean
- ✅ example app (`examples/electron-control-panel`) `tsc --noEmit` clean

## Downstream

The palimpsest-engine call site (which triggered this) is tracked in that repo's `ISSUE-diffusion-calibration-cfgscale.md` — it needs to bump to `^0.12.0` and pass its production `cfgScale` (`1` for Flux Klein) through the calibrate chain.

## Post-merge

Tag `v0.12.0` → GitHub release → `npm publish` (maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUnbdtaZgHpx5Sg3Yj6fWA
